### PR TITLE
Fix for if rating is null

### DIFF
--- a/src/components/ReviewsPage/Score.tsx
+++ b/src/components/ReviewsPage/Score.tsx
@@ -16,7 +16,11 @@ function Score({ rating, name }: Props) {
   }
   return (
     <div className="bu_score">
-      <div className={`bu_score__rating bu_card ${color}`}>{rating.toFixed(1)}</div>
+      {rating && (
+        <div className={`bu_score__rating bu_card ${color}`}>
+          {rating.toFixed(1)}
+        </div>
+      )}
       <div>{name}</div>
     </div>
   );


### PR DESCRIPTION
It is possible that the rating for a house is `NULL` if there is not yet a review