### PR TITLE
Remove dotenv dependency from package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "autoprefixer": "^10.4.13",
         "chalk": "1.1.3",
         "cypress": "^13.1.0",
-        "dotenv": "4.0.0",
         "eslint": "^8.49.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-prettier": "^4.2.1",
@@ -6015,16 +6014,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha512-XcaMACOr3JMVcEv0Y/iUM2XaOsATRZ3U1In41/1jjK6vJZ2PZbQ1bzCG8uvaByfaBpl9gqc9QWJovpUGBXLLYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.6.0"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -16185,12 +16174,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha512-XcaMACOr3JMVcEv0Y/iUM2XaOsATRZ3U1In41/1jjK6vJZ2PZbQ1bzCG8uvaByfaBpl9gqc9QWJovpUGBXLLYQ==",
-      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "autoprefixer": "^10.4.13",
     "chalk": "1.1.3",
     "cypress": "^13.1.0",
-    "dotenv": "4.0.0",
     "eslint": "^8.49.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change removes the `dotenv` package version 4.0.0 from the dependencies list.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32): Removed the `dotenv` package version 4.0.0 from the dependencies list.