### PR TITLE
Add assignees and limit for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    assignees:
+      - "bobvanoorschot"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "bobvanoorschot"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to improve dependency management and workflow automation. It increases the limit for open pull requests and assigns responsibility for reviewing updates.

Dependabot configuration improvements:

* Increased the `open-pull-requests-limit` for npm updates to 10, allowing more simultaneous dependency update PRs.
* Set `bobvanoorschot` as the assignee for both npm and GitHub Actions Dependabot PRs, ensuring clear ownership for dependency updates.
* Added a new configuration for monitoring and updating GitHub Actions workflows with Dependabot.