### PR TITLE
ci: update Node.js versions to support 18.x through 24.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 22
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 22
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
       - run: npm ci


### PR DESCRIPTION
This pull request updates our CI workflows to use newer versions of Node.js, ensuring better compatibility with the latest features and improved long-term support. The main changes are focused on updating the Node.js versions used in both testing and publishing workflows.

**CI and Publishing Workflow Updates:**

- **Node.js Version Matrix Update:**
  - Updated the Node.js version matrix in `.github/workflows/node.js.yml` to test against Node.js versions 18.x, 20.x, 22.x, and 24.x, removing 16.x and adding 22.x and 24.x.

- **NPM Publish Workflow Update:**
  - Changed the Node.js version used for publishing in `.github/workflows/npm-publish.yml` from 16 to 22 in both the main job and the release job. [[1]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L24-R24) [[2]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L42-R42)