### PR TITLE
chore: add tmp directory to gitignore and remove cached files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ build
 
 yarn-error.log
 
+tmp
+/tmp
+
 coverage
 coverage/*

--- a/tmp/cache/vite/last-build-production.json
+++ b/tmp/cache/vite/last-build-production.json
@@ -1,7 +1,0 @@
-{
-  "success": true,
-  "errors": "",
-  "timestamp": "2023-12-17 20:02:20",
-  "vite_ruby": "3.5.0",
-  "digest": "e2f9ab032527460979fee322a51ecfd0d988e882"
-}


### PR DESCRIPTION
This pull request removes the `tmp/cache/vite/last-build-production.json` file, which likely contained cached build metadata for Vite in production. This is a simple cleanup change and should not affect application functionality.

* Deleted the `tmp/cache/vite/last-build-production.json` file to clean up cached build metadata.