### PR TITLE
feat: create version branch during npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,7 +61,7 @@ jobs:
           git checkout master
       - run: npm ci
       - run: npm run build
-      - run: npm publish --tag ${{ env.VERSION }}
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
       - name: Create GitHub Release


### PR DESCRIPTION
This pull request updates the npm publish workflow to improve version management and branching. The key changes focus on automating the creation of a new branch for each version bump and ensuring the correct version is used throughout the process.

**Workflow improvements:**

* After bumping the version, the workflow now extracts the new version from `package.json` and stores it in the environment for later steps.
* A new branch named after the new version (e.g., `v1.2.3`) is created for each version bump, and commits are made to this branch instead of directly to `master`.
* The workflow now uses a standard `git push` instead of `--force-with-lease`, and checks out `master` after pushing the new branch.