### PR TITLE
Refactor CSS styles for calendar, field, and form components

### DIFF
--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -52,7 +52,6 @@
     .bu-calendar-col {
       .icon {
         padding: 8px 40px;
-        background-color: rgb(23, 190, 187);
         background: var(--bukazu-button);
         cursor: pointer;
         display: flex;
@@ -75,9 +74,7 @@
   .bu-smaller .calendar {
     width: 100%;
   }
-  .bu-smaller .calendar .col {
-    padding: 16px 4px;
-  }
+  .bu-smaller .calendar .col,
   .bu-smaller .calendar .bu-calendar-col {
     padding: 16px 4px;
   }
@@ -180,7 +177,6 @@
       cursor: pointer;
     }
     .selected {
-      background: rgb(23, 190, 187) !important;
       background: var(--bukazu-button) !important;
     }
     .booked {

--- a/src/styles/field.css
+++ b/src/styles/field.css
@@ -1,19 +1,17 @@
 #bukazu-app {
-    input, select {
-        appearance: none;
-        border: 1px solid rgba(69, 74, 83, 0.2);
-        border-radius: 8px;
-        padding: 8px 16px;
-        font-size: 16px;
-        width: 100%;
-        box-sizing: border-box;
-        margin: 4px 0 8px;
-    }
+    input,
+    select,
     .react-date-picker__wrapper {
         border: 1px solid rgba(69, 74, 83, 0.2);
         border-radius: 8px;
         padding: 8px 16px;
         margin: 4px 0 8px;
+    }
+    input, select {
+        appearance: none;
+        font-size: 16px;
+        width: 100%;
+        box-sizing: border-box;
     }
     .react-date-picker__inputGroup {
         box-sizing: content-box;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -124,8 +124,6 @@
     .terms {
       padding: 8px 0;
       button {
-        padding: 0 4px;
-        background: 0;
         display: inline;
         width: auto;
         font-size: 16px;


### PR DESCRIPTION
This pull request makes several improvements to the calendar and form styling, focusing on consistency and maintainability. The main changes include standardizing the use of CSS variables for button backgrounds, unifying padding rules in the calendar, and refactoring input and date picker field styles for better code reuse and appearance.

**Calendar style updates:**

* Replaced hardcoded background colors with the `var(--bukazu-button)` CSS variable for both the `.icon` and `.selected` states to ensure consistent theming. [[1]](diffhunk://#diff-050f3746f0a69dbf664a3b1c13cc45b1747ee32460309f9feec0a9a250828c7fL55) [[2]](diffhunk://#diff-050f3746f0a69dbf664a3b1c13cc45b1747ee32460309f9feec0a9a250828c7fL183)
* Unified padding for `.col` and `.bu-calendar-col` elements in the `.bu-smaller .calendar` context to simplify and standardize the layout.

**Field and form style refactoring:**

* Consolidated input, select, and `.react-date-picker__wrapper` styles in `field.css` to reduce duplication and improve maintainability. This includes shared border, padding, and margin rules.
* Simplified the `.terms button` styling in `form.css` by removing unnecessary padding and background rules.