### PR TITLE
Fix rendering with react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "rollup-plugin-visualizer": "^7.0.1",
         "terser": "^5.46.0",
         "ts-jest": "^29.0.5",
+        "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.3",
         "whatwg-fetch": "3.6.20"
@@ -2024,6 +2025,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
       "version": "3.0.0",
@@ -4767,6 +4792,34 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5275,6 +5328,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5364,6 +5430,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -6062,6 +6135,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -6467,6 +6547,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -12990,6 +13080,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.1",
       "license": "0BSD"
@@ -13289,6 +13423,13 @@
       "version": "2.0.3",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -13714,6 +13855,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rollup-plugin-visualizer": "^7.0.1",
     "terser": "^5.46.0",
     "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.3",
     "whatwg-fetch": "3.6.20"

--- a/src/_lib/__tests__/graphql_request.test.ts
+++ b/src/_lib/__tests__/graphql_request.test.ts
@@ -1,5 +1,6 @@
 import { GraphQLClient } from 'graphql-request';
-import { createGraphQLRequestClient, toApolloError } from '../graphql_request';
+import { GraphQLError } from 'graphql';
+import { createGraphQLRequestClient, toGraphQLErrors } from '../graphql_request';
 
 jest.mock('graphql-request', () => ({
   GraphQLClient: jest.fn()
@@ -39,9 +40,19 @@ describe('graphql_request helpers', () => {
     );
   });
 
-  it('maps unknown errors to ApolloError', () => {
-    const error = toApolloError(new Error('boom'));
+  it('maps unknown errors to GraphQLErrors', () => {
+    const error = toGraphQLErrors(new Error('boom'));
 
-    expect(error.graphQLErrors[0].message).toBe('boom');
+    expect(error[0].message).toBe('boom');
+  });
+
+  it('returns GraphQLErrors from a GraphQL response error', () => {
+    const graphQLError = new GraphQLError('resolver failed');
+
+    const errors = toGraphQLErrors({
+      response: { errors: [graphQLError] }
+    });
+
+    expect(errors).toEqual([graphQLError]);
   });
 });

--- a/src/_lib/__tests__/graphql_request.test.ts
+++ b/src/_lib/__tests__/graphql_request.test.ts
@@ -1,6 +1,9 @@
 import { GraphQLClient } from 'graphql-request';
 import { GraphQLError } from 'graphql';
-import { createGraphQLRequestClient, toGraphQLErrors } from '../graphql_request';
+import {
+  createGraphQLRequestClient,
+  toGraphQLErrors
+} from '../graphql_request';
 
 jest.mock('graphql-request', () => ({
   GraphQLClient: jest.fn()

--- a/src/_lib/graphql_request.ts
+++ b/src/_lib/graphql_request.ts
@@ -30,8 +30,12 @@ function hasGraphQLResponseErrors(
 }
 
 export function toGraphQLErrors(error: unknown): GraphQLError[] {
-  if (hasGraphQLResponseErrors(error) && error.response?.errors !== undefined) {
-    return [...error.response.errors];
+  if (hasGraphQLResponseErrors(error)) {
+    const { errors } = error.response ?? {};
+
+    if (errors !== undefined && errors.length > 0) {
+      return [...errors];
+    }
   }
 
   const message =

--- a/src/_lib/graphql_request.ts
+++ b/src/_lib/graphql_request.ts
@@ -1,6 +1,11 @@
-import { ApolloError } from '@apollo/client';
 import { GraphQLError } from 'graphql';
 import { GraphQLClient } from 'graphql-request';
+
+interface GraphQLResponseError {
+  response?: {
+    errors?: readonly GraphQLError[];
+  };
+}
 
 export function createGraphQLRequestClient(
   apiUrl: string,
@@ -13,15 +18,24 @@ export function createGraphQLRequestClient(
   });
 }
 
-export function toApolloError(error: unknown): ApolloError {
-  if (error instanceof ApolloError) {
-    return error;
+function hasGraphQLResponseErrors(
+  error: unknown
+): error is GraphQLResponseError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    Array.isArray((error as GraphQLResponseError).response?.errors)
+  );
+}
+
+export function toGraphQLErrors(error: unknown): GraphQLError[] {
+  if (hasGraphQLResponseErrors(error) && error.response?.errors !== undefined) {
+    return [...error.response.errors];
   }
 
   const message =
     error instanceof Error ? error.message : 'A GraphQL request failed';
 
-  return new ApolloError({
-    graphQLErrors: [new GraphQLError(message)]
-  });
+  return [new GraphQLError(message)];
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,12 +7,12 @@ import ReviewsPageMount from './ReviewsPage/ReviewsPageMount';
 import SafeBooking from './SafeBooking';
 import { ApiError } from './Error';
 import ErrorBoundary from './ErrorBoundary';
-import { ApolloError } from '@apollo/client';
+import { GraphQLError } from 'graphql';
 import { AppContext } from './AppContext';
 import { FiltersType } from './SearchPage/filters/filter_types';
 import { ColorsType } from '../types';
 import { loadPortalSite, type AppPortalSite } from './loadPortalSite';
-import { toApolloError } from '../_lib/graphql_request';
+import { toGraphQLErrors } from '../_lib/graphql_request';
 import { GraphQLClientContext } from '../_lib/GraphQLClientContext';
 
 interface Props {
@@ -23,7 +23,7 @@ interface Props {
 
 type AppState =
   | { status: 'loading' }
-  | { status: 'error'; error: ApolloError }
+  | { status: 'error'; error: GraphQLError[] }
   | { status: 'ready'; portalSite: AppPortalSite };
 
 function App({ pageType, locale, filters = {} }: Props): JSX.Element {
@@ -48,7 +48,7 @@ function App({ pageType, locale, filters = {} }: Props): JSX.Element {
         if (!isMounted) {
           return;
         }
-        setState({ status: 'error', error: toApolloError(error) });
+        setState({ status: 'error', error: toGraphQLErrors(error) });
       });
 
     return () => {

--- a/src/components/CalendarPage/FormCreator.tsx
+++ b/src/components/CalendarPage/FormCreator.tsx
@@ -131,7 +131,7 @@ function FormCreator({ house, PortalSite }: Props): JSX.Element {
           {loading && <div className="return-message">Creating booking...</div>}
           {error && (
             <Modal show={true} onClose={reset}>
-              <ApiError errors={error} modal={true} />
+              <ApiError errors={error} />
             </Modal>
           )}
           {data && (

--- a/src/components/Error/ApiError.tsx
+++ b/src/components/Error/ApiError.tsx
@@ -24,10 +24,7 @@ function getGraphQLErrors(
   return errorSource;
 }
 
-function ApiError(
-  errors: ApiErrorProps,
-  modal: boolean = false
-): JSX.Element {
+function ApiError(errors: ApiErrorProps, modal: boolean = false): JSX.Element {
   const graphQLErrors = getGraphQLErrors(errors.errors);
 
   if (
@@ -41,9 +38,7 @@ function ApiError(
 
   const errorMessage = (
     <div className="bukazu-error-message">
-      <h2>
-        {t('something_went_wrong_please_try_again')}
-      </h2>
+      <h2>{t('something_went_wrong_please_try_again')}</h2>
       <ul>
         {graphQLErrors.map((err) => (
           <li key={err.message}>{err.message}</li>

--- a/src/components/Error/ApiError.tsx
+++ b/src/components/Error/ApiError.tsx
@@ -1,18 +1,42 @@
 import React from 'react';
 import Modal from '../Modal';
 import { t } from '../../intl';
-import { ApolloError } from '@apollo/client';
+import { GraphQLError } from 'graphql';
 import { reportError } from '../../_lib/sentry';
 
-const reportedErrors = new WeakSet<ApolloError>();
+type GraphQLErrorSource = {
+  graphQLErrors: readonly GraphQLError[];
+};
+
+type ApiErrorProps = {
+  errors: readonly GraphQLError[] | GraphQLErrorSource;
+};
+
+const reportedErrors = new WeakSet<object>();
+
+function getGraphQLErrors(
+  errorSource: readonly GraphQLError[] | GraphQLErrorSource
+): readonly GraphQLError[] {
+  if ('graphQLErrors' in errorSource) {
+    return errorSource.graphQLErrors;
+  }
+
+  return errorSource;
+}
 
 function ApiError(
-  errors: { errors: ApolloError },
+  errors: ApiErrorProps,
   modal: boolean = false
 ): JSX.Element {
-  if (!reportedErrors.has(errors.errors)) {
+  const graphQLErrors = getGraphQLErrors(errors.errors);
+
+  if (
+    typeof errors.errors === 'object' &&
+    errors.errors !== null &&
+    !reportedErrors.has(errors.errors)
+  ) {
     reportedErrors.add(errors.errors);
-    reportError(errors.errors);
+    reportError(new Error(graphQLErrors.map((err) => err.message).join('\n')));
   }
 
   const errorMessage = (
@@ -21,7 +45,7 @@ function ApiError(
         {t('something_went_wrong_please_try_again')}
       </h2>
       <ul>
-        {errors.errors.graphQLErrors.map((err) => (
+        {graphQLErrors.map((err) => (
           <li key={err.message}>{err.message}</li>
         ))}
       </ul>

--- a/src/components/Error/ApiError.tsx
+++ b/src/components/Error/ApiError.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Modal from '../Modal';
 import { t } from '../../intl';
 import { GraphQLError } from 'graphql';
 import { reportError } from '../../_lib/sentry';
@@ -24,7 +23,7 @@ function getGraphQLErrors(
   return errorSource;
 }
 
-function ApiError(errors: ApiErrorProps, modal: boolean = false): JSX.Element {
+function ApiError(errors: ApiErrorProps): JSX.Element {
   const graphQLErrors = getGraphQLErrors(errors.errors);
 
   if (
@@ -36,7 +35,7 @@ function ApiError(errors: ApiErrorProps, modal: boolean = false): JSX.Element {
     reportError(new Error(graphQLErrors.map((err) => err.message).join('\n')));
   }
 
-  const errorMessage = (
+  return (
     <div className="bukazu-error-message">
       <h2>{t('something_went_wrong_please_try_again')}</h2>
       <ul>
@@ -46,11 +45,6 @@ function ApiError(errors: ApiErrorProps, modal: boolean = false): JSX.Element {
       </ul>
     </div>
   );
-  if (modal == true) {
-    return <Modal show={true}>{errorMessage}</Modal>;
-  }
-
-  return errorMessage;
 }
 
 export default ApiError;

--- a/src/components/Error/__tests__/ApiError.test.tsx
+++ b/src/components/Error/__tests__/ApiError.test.tsx
@@ -15,14 +15,6 @@ jest.mock('../../../_lib/sentry', () => ({
   reportError: jest.fn()
 }));
 
-jest.mock(
-  '../../Modal',
-  () =>
-    ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="modal">{children}</div>
-    )
-);
-
 jest.mock('../../../intl', () => ({
   t: (id: string) => id
 }));
@@ -71,19 +63,6 @@ describe('ApiError', () => {
 
     expect(sentryLib.reportError).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'GraphQL error' })
-    );
-  });
-
-  it('wraps the error in a Modal when modal=true', () => {
-    const error = makeGraphQLErrors(['Modal error']);
-
-    act(() => {
-      root.render(<>{ApiError({ errors: error }, true)}</>);
-    });
-
-    expect(container.querySelector('[data-testid="modal"]')).not.toBeNull();
-    expect(sentryLib.reportError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Modal error' })
     );
   });
 

--- a/src/components/Error/__tests__/ApiError.test.tsx
+++ b/src/components/Error/__tests__/ApiError.test.tsx
@@ -5,9 +5,9 @@
 import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
+import { GraphQLError } from 'graphql';
 import * as sentryLib from '../../../_lib/sentry';
 import ApiError from '../ApiError';
-import { ApolloError } from '@apollo/client';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -42,16 +42,13 @@ afterEach(() => {
   container.remove();
 });
 
-function makeApolloError(messages: string[]): ApolloError {
-  const error = new ApolloError({
-    graphQLErrors: messages.map((m) => ({ message: m } as any))
-  });
-  return error;
+function makeGraphQLErrors(messages: string[]): GraphQLError[] {
+  return messages.map((message) => new GraphQLError(message));
 }
 
 describe('ApiError', () => {
   it('renders error messages from graphQLErrors', () => {
-    const error = makeApolloError(['Something failed']);
+    const error = makeGraphQLErrors(['Something failed']);
 
     act(() => {
       root.render(<>{ApiError({ errors: error })}</>);
@@ -62,23 +59,37 @@ describe('ApiError', () => {
   });
 
   it('reports the error to Sentry when rendered', () => {
-    const error = makeApolloError(['GraphQL error']);
+    const error = makeGraphQLErrors(['GraphQL error']);
 
     act(() => {
       root.render(<>{ApiError({ errors: error })}</>);
     });
 
-    expect(sentryLib.reportError).toHaveBeenCalledWith(error);
+    expect(sentryLib.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'GraphQL error' })
+    );
   });
 
   it('wraps the error in a Modal when modal=true', () => {
-    const error = makeApolloError(['Modal error']);
+    const error = makeGraphQLErrors(['Modal error']);
 
     act(() => {
       root.render(<>{ApiError({ errors: error }, true)}</>);
     });
 
     expect(container.querySelector('[data-testid="modal"]')).not.toBeNull();
-    expect(sentryLib.reportError).toHaveBeenCalledWith(error);
+    expect(sentryLib.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Modal error' })
+    );
+  });
+
+  it('supports Apollo-style callers that pass graphQLErrors on an object', () => {
+    const error = { graphQLErrors: makeGraphQLErrors(['Object-shaped error']) };
+
+    act(() => {
+      root.render(<>{ApiError({ errors: error })}</>);
+    });
+
+    expect(container.textContent).toContain('Object-shaped error');
   });
 });

--- a/src/components/Error/__tests__/ApiError.test.tsx
+++ b/src/components/Error/__tests__/ApiError.test.tsx
@@ -15,9 +15,13 @@ jest.mock('../../../_lib/sentry', () => ({
   reportError: jest.fn()
 }));
 
-jest.mock('../../Modal', () => ({ children }: { children: React.ReactNode }) => (
-  <div data-testid="modal">{children}</div>
-));
+jest.mock(
+  '../../Modal',
+  () =>
+    ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="modal">{children}</div>
+    )
+);
 
 jest.mock('../../../intl', () => ({
   t: (id: string) => id

--- a/src/components/ReviewsPage/ReviewsPageMount.tsx
+++ b/src/components/ReviewsPage/ReviewsPageMount.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { ApolloError } from '@apollo/client';
-import { toApolloError } from '../../_lib/graphql_request';
+import { GraphQLError } from 'graphql';
+import { toGraphQLErrors } from '../../_lib/graphql_request';
 import { GraphQLClientContext } from '../../_lib/GraphQLClientContext';
 import { mountPlainNode } from '../../_lib/plain_mount';
 import { ApiError } from '../Error';
@@ -15,7 +15,7 @@ interface Props {
 
 type ReviewsPageState =
   | { status: 'loading' }
-  | { status: 'error'; error: ApolloError }
+  | { status: 'error'; error: GraphQLError[] }
   | { status: 'ready'; house: ReviewsHouse };
 
 function ReviewsPageDom({ house }: { house: ReviewsHouse }): JSX.Element {
@@ -53,7 +53,7 @@ function ReviewsPageMount({ objectCode, portalCode }: Props): JSX.Element {
         if (!isMounted) {
           return;
         }
-        setState({ status: 'error', error: toApolloError(error) });
+        setState({ status: 'error', error: toGraphQLErrors(error) });
       });
 
     return () => {

--- a/src/components/ReviewsPage/__tests__/ReviewsPage.test.tsx
+++ b/src/components/ReviewsPage/__tests__/ReviewsPage.test.tsx
@@ -15,7 +15,7 @@ jest.mock('../../icons/loading.svg', () => () => <svg data-testid="loading" />);
 
 jest.mock('../../Error', () => ({
   ApiError: ({ errors }: { errors: any }) => (
-    <div data-testid="api-error">{errors.message}</div>
+    <div data-testid="api-error">{errors[0]?.message}</div>
   )
 }));
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -24,8 +24,8 @@ jest.mock('../ReviewsPage/ReviewsPageMount', () => () => (
 ));
 jest.mock('../SafeBooking', () => () => '<div class="safe-booking"></div>');
 jest.mock('../Error', () => ({
-  ApiError: ({ errors }: { errors?: { message: string } }) => (
-    <div data-testid="api-error">{errors?.message}</div>
+  ApiError: ({ errors }: { errors?: Array<{ message: string }> }) => (
+    <div data-testid="api-error">{errors?.[0]?.message}</div>
   )
 }));
 jest.mock(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,11 +44,18 @@ export default defineConfig({
       cssFileName: 'index'
     },
     rolldownOptions: {
-      external: ['react', 'react-dom'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime'
+      ],
       output: {
         globals: {
           react: 'React',
-          'react-dom': 'ReactDOM'
+          'react-dom': 'ReactDOM',
+          'react/jsx-runtime': 'ReactJSXRuntime',
+          'react/jsx-dev-runtime': 'ReactJSXDevRuntime'
         },
         minify: true
       }


### PR DESCRIPTION
This pull request refactors error handling in the application to remove the dependency on Apollo Client's `ApolloError` in favor of using the standard `GraphQLError` from the `graphql` package. The main goal is to simplify error handling and make it more consistent across the codebase, especially for GraphQL request failures. This change affects error creation, propagation, and display in both the main app and reviews page, as well as their corresponding tests.

**Error Handling Refactor:**

- Replaced all usage of `ApolloError` with arrays of `GraphQLError` throughout the app, including state types and error reporting. (`src/components/App.tsx`, `src/components/ReviewsPage/ReviewsPageMount.tsx`, `src/components/Error/ApiError.tsx`) [[1]](diffhunk://#diff-86963609bec6fda3d34233676d5ae33f6aa4b9bbe2758a10cd4863b704b37093L10-R15) [[2]](diffhunk://#diff-380401005a35f45d81ec679f0f6574393ea741010d1738766dd387b14f46132dL2-R3) [[3]](diffhunk://#diff-65b1d31cb385fc098e75e7281d7f31507d12c081e7173ac24c30d81f741f69b3L4-R43)
- Introduced the new `toGraphQLErrors` helper in `graphql_request.ts` to standardize conversion of unknown errors into `GraphQLError[]`, replacing the previous `toApolloError` function. (`src/_lib/graphql_request.ts`)
- Updated all error handling logic in the app and reviews page to use `toGraphQLErrors` instead of `toApolloError`. (`src/components/App.tsx`, `src/components/ReviewsPage/ReviewsPageMount.tsx`) [[1]](diffhunk://#diff-86963609bec6fda3d34233676d5ae33f6aa4b9bbe2758a10cd4863b704b37093L51-R51) [[2]](diffhunk://#diff-380401005a35f45d81ec679f0f6574393ea741010d1738766dd387b14f46132dL56-R56)

**Error Display and Reporting:**

- Refactored the `ApiError` component to accept and display arrays of `GraphQLError` or Apollo-style error objects, and to report errors to Sentry as concatenated messages. (`src/components/Error/ApiError.tsx`)
- Updated tests and test mocks to use `GraphQLError[]` instead of `ApolloError`, ensuring compatibility with the new error handling approach. (`src/components/Error/__tests__/ApiError.test.tsx`, `src/components/__tests__/App.test.tsx`, `src/components/ReviewsPage/__tests__/ReviewsPage.test.tsx`) [[1]](diffhunk://#diff-77e93b30ebb32d65c8d8a777734c5f43b100b95f1ff1a2ffa3b42b8fcab7cb39L45-R55) [[2]](diffhunk://#diff-2b6be56aea5b16fa7d58fc5f88b73d70eb5aef0a4ee6d61e45b2af38f7a97cc7L27-R28) [[3]](diffhunk://#diff-0c9e0c859ca806156199294a1918cfc1edf3a77b5f4e19b040d231abac609620L18-R18)

**Testing and Compatibility:**

- Added and updated test cases to verify the new error handling logic, including support for both array and object-shaped error inputs. (`src/components/Error/__tests__/ApiError.test.tsx`)
- Adjusted test mocks for error components to expect arrays of errors. (`src/components/__tests__/App.test.tsx`, `src/components/ReviewsPage/__tests__/ReviewsPage.test.tsx`) [[1]](diffhunk://#diff-2b6be56aea5b16fa7d58fc5f88b73d70eb5aef0a4ee6d61e45b2af38f7a97cc7L27-R28) [[2]](diffhunk://#diff-0c9e0c859ca806156199294a1918cfc1edf3a77b5f4e19b040d231abac609620L18-R18)

**Build Configuration:**

- Updated Vite build configuration to mark `react/jsx-runtime` and `react/jsx-dev-runtime` as external dependencies and provide the necessary global mappings for bundling. (`vite.config.ts`)

These changes collectively remove the Apollo Client dependency for error handling, streamline error propagation, and improve consistency and maintainability in how GraphQL errors are managed and displayed.