### PR TITLE
refactor: update package.json and vite.config.ts for ESM-only support

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,16 +68,14 @@
     "graphql": "^16.11.0",
     "ky": "^2.0.2"
   },
-  "main": "./build/portal.umd.js",
-  "module": "./build/portal.es.js",
   "exports": {
     ".": {
-      "import": "./build/portal.es.js",
-      "require": "./build/portal.umd.js"
+      "import": "./build/portal.es.js"
     },
     "./index.css": "./build/index.css",
     "./build/index.css": "./build/index.css"
   },
+  "sideEffects": false,
   "eslintConfig": {
     "extends": [
       "eslint:recommended",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "./index.css": "./build/index.css",
     "./build/index.css": "./build/index.css"
   },
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "eslintConfig": {
     "extends": [
       "eslint:recommended",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,10 +54,7 @@ export default defineConfig({
         'react-dom',
         'react/jsx-runtime',
         'react/jsx-dev-runtime'
-      ],
-      output: {
-        minify: true
-      }
+      ]
     }
   }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,12 @@ export default defineConfig({
         ]
       : [])
   ],
+  resolve: {
+    mainFields: ['module', 'browser', 'main'],
+    alias: {
+      rehackt: 'react'
+    }
+  },
   server: {
     host: true
   },
@@ -38,9 +44,8 @@ export default defineConfig({
     },
     lib: {
       entry: resolve(__dirname, 'src/index.tsx'),
-      name: 'BukazuPortal',
-      formats: ['es', 'umd'],
-      fileName: (format) => `portal.${format}.js`,
+      formats: ['es'],
+      fileName: () => 'portal.es.js',
       cssFileName: 'index'
     },
     rolldownOptions: {
@@ -51,12 +56,6 @@ export default defineConfig({
         'react/jsx-dev-runtime'
       ],
       output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'react/jsx-runtime': 'ReactJSXRuntime',
-          'react/jsx-dev-runtime': 'ReactJSXDevRuntime'
-        },
         minify: true
       }
     }


### PR DESCRIPTION
This pull request updates the build configuration to simplify the output format and improve compatibility and optimization. The main changes are the removal of the UMD build, adjustments to module resolution, and the addition of optimizations for tree-shaking.

**Build output and configuration changes:**

* The UMD build format and related entry points (`main` and `require`) have been removed from both `vite.config.ts` and `package.json`, leaving only the ES module build (`portal.es.js`). (`[[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL41-R48)`, `[[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L71-R78)`)
* The `sideEffects` field is set to `false` in `package.json` to enable better tree-shaking and dead code elimination during bundling. (`[package.jsonL71-R78](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L71-R78)`)

**Module resolution and compatibility:**

* The Vite config now explicitly sets `mainFields` to prioritize the `module` and `browser` fields, improving how dependencies are resolved for modern environments. (`[vite.config.tsR22-R27](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR22-R27)`)
* An alias is added to resolve `rehackt` imports to `react`, possibly to address a typo or compatibility issue. (`[vite.config.tsR22-R27](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR22-R27)`)

**Other build changes:**

* The `globals` configuration for UMD builds has been removed since UMD output is no longer supported. (`[vite.config.tsL54-L59](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL54-L59)`)