### PR TITLE
refactor: remove Formik

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@apollo/client": "^3.11.8",
         "@sentry/browser": "^10.45.0",
-        "formik": "^2.2.9",
         "graphql": "^16.11.0",
         "ky": "^2.0.2"
       },
@@ -5637,14 +5636,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "dev": true,
@@ -5690,10 +5681,12 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.0.26",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5711,6 +5704,7 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -7096,6 +7090,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7207,13 +7202,6 @@
       "version": "0.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -8147,29 +8135,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/formik": {
-      "version": "2.4.9",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://opencollective.com/formik"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "deepmerge": "^2.1.1",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "react-fast-compare": "^2.0.1",
-        "tiny-warning": "^1.0.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/fraction.js": {
@@ -11177,18 +11142,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -12819,6 +12772,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -12838,10 +12792,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-fast-compare": {
-      "version": "2.0.4",
-      "license": "MIT"
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -13903,10 +13853,6 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "@apollo/client": "^3.11.8",
     "@sentry/browser": "^10.45.0",
-    "formik": "^2.2.9",
     "graphql": "^16.11.0",
     "ky": "^2.0.2"
   },

--- a/src/components/CalendarPage/formParts/__tests__/BookingOrOption.test.tsx
+++ b/src/components/CalendarPage/formParts/__tests__/BookingOrOption.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Formik } from 'formik';
 import BookingOrOption from '../BookingOrOption';
 import { HouseType } from '../../../../types';
 
@@ -42,9 +41,7 @@ function renderBookingOrOption(housePatch: Partial<typeof baseHouse> = {}) {
   const house = { ...baseHouse, ...housePatch };
   act(() => {
     root.render(
-      <Formik initialValues={{ is_option: 'false' }} onSubmit={() => {}}>
-        <BookingOrOption house={house as unknown as HouseType} />
-      </Formik>
+      <BookingOrOption house={house as unknown as HouseType} />
     );
   });
 }

--- a/src/components/CalendarPage/formParts/__tests__/DiscountCode.test.tsx
+++ b/src/components/CalendarPage/formParts/__tests__/DiscountCode.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Formik } from 'formik';
 import DiscountCode from '../DiscountCode';
 import { HouseType } from '../../../../types';
 
@@ -63,11 +62,7 @@ function renderDiscountCode(mutationState: {
   ]);
 
   act(() => {
-    root.render(
-      <Formik initialValues={{ discount_code: '' }} onSubmit={() => {}}>
-        <DiscountCode house={baseHouse} />
-      </Formik>
-    );
+    root.render(<DiscountCode house={baseHouse} />);
   });
 }
 
@@ -170,11 +165,7 @@ describe('DiscountCode – input interaction', () => {
     ]);
 
     act(() => {
-      root.render(
-        <Formik initialValues={{ discount_code: '' }} onSubmit={() => {}}>
-          <DiscountCode house={baseHouse} />
-        </Formik>
-      );
+      root.render(<DiscountCode house={baseHouse} />);
     });
 
     const input = container.querySelector('input') as HTMLInputElement;

--- a/src/components/CalendarPage/formParts/__tests__/OptionalCosts.test.tsx
+++ b/src/components/CalendarPage/formParts/__tests__/OptionalCosts.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Formik } from 'formik';
 import OptionalCosts from '../OptionalCosts';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -39,11 +38,7 @@ afterEach(() => {
 
 function renderOptionalCosts(costs: any[]) {
   act(() => {
-    root.render(
-      <Formik initialValues={{}} onSubmit={() => {}}>
-        <OptionalCosts costs={costs} />
-      </Formik>
-    );
+    root.render(<OptionalCosts costs={costs} />);
   });
 }
 

--- a/src/components/CalendarPage/formParts/__tests__/insurances.test.tsx
+++ b/src/components/CalendarPage/formParts/__tests__/insurances.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Formik } from 'formik';
 import { Insurances } from '../insurances';
 import { HouseType } from '../../../../types';
 
@@ -65,9 +64,7 @@ function renderInsurances(
 
   act(() => {
     root.render(
-      <Formik initialValues={values} onSubmit={() => {}}>
-        <Insurances house={house as unknown as HouseType} values={values as any} />
-      </Formik>
+      <Insurances house={house as unknown as HouseType} values={values as any} />
     );
   });
 }


### PR DESCRIPTION
This pull request removes the dependency on Formik from several test files and updates the corresponding test implementations to render components directly, instead of wrapping them in a Formik context. It also removes Formik from the project's dependencies.

Dependency removal:

* Removed the `formik` package from the `dependencies` section in `package.json`.

Test file updates:

* Removed all Formik imports and usage from the test files: `BookingOrOption.test.tsx`, `DiscountCode.test.tsx`, `OptionalCosts.test.tsx`, and `insurances.test.tsx`. Now, components are rendered directly in tests without being wrapped in a Formik provider. [[1]](diffhunk://#diff-324de2504e0ac2f8d611e6d07a9a6ec45075025dec8791716ec392ba7f4709beL4) [[2]](diffhunk://#diff-324de2504e0ac2f8d611e6d07a9a6ec45075025dec8791716ec392ba7f4709beL45-L47) [[3]](diffhunk://#diff-53d0dfc132fb54d18788930b720bab97c2905cbce4230e5699e8d97b66fbc241L4) [[4]](diffhunk://#diff-53d0dfc132fb54d18788930b720bab97c2905cbce4230e5699e8d97b66fbc241L66-R65) [[5]](diffhunk://#diff-53d0dfc132fb54d18788930b720bab97c2905cbce4230e5699e8d97b66fbc241L173-R168) [[6]](diffhunk://#diff-92e6317dd48c427045cbf56399ce056468a15517d879ba61e9b60b20861d7636L4) [[7]](diffhunk://#diff-92e6317dd48c427045cbf56399ce056468a15517d879ba61e9b60b20861d7636L42-R41) [[8]](diffhunk://#diff-75147373fb586c48e003e4d953352402aabb298286ba42bb0a16286c1bcda87bL4) [[9]](diffhunk://#diff-75147373fb586c48e003e4d953352402aabb298286ba42bb0a16286c1bcda87bL68-L70)