### PR TITLE
feat: load the calendar accommodation through the REST API

### DIFF
--- a/e2e/booking-form.spec.ts
+++ b/e2e/booking-form.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 /**
  * E2E tests for the Bukazu Portal booking form, using Playwright route
- * interception to control GraphQL API responses.
+ * interception to control the REST portal API responses.
  *
  * These tests verify booking form interactions that cannot be exercised with
  * unit tests alone (real DOM rendering, real Formik field value propagation,
@@ -10,7 +10,7 @@ import { test, expect } from '@playwright/test';
  *
  * Strategy
  * ---------
- * • Every test intercepts POST requests to the Bukazu GraphQL endpoint and
+ * • Every test intercepts the /portal_api/v1 requests the portal makes and
  *   returns deterministic JSON fixtures.
  * • Three fixture variants are provided:
  *     1. houseWithoutInsurance  – cancel_insurance: false (baseline)
@@ -18,7 +18,8 @@ import { test, expect } from '@playwright/test';
  *     3. houseWithOptionalCosts – has bookable optional costs
  */
 
-const GQL_URL = 'https://api.bukazu.com/graphql';
+const DETAIL_URL =
+  'https://api.bukazu.com/portal_api/v1/accommodations/detail**';
 const BOOKINGS_URL =
   'https://api.bukazu.com/portal_api/v1/accommodations/bookings**';
 
@@ -49,43 +50,6 @@ function makeBookingResponse() {
 // Shared fixtures
 // ---------------------------------------------------------------------------
 
-const bookingFormConfiguration = {
-  adultsFromAge: 18,
-  babiesAllowed: false,
-  babiesTillAge: 2,
-  childrenAllowed: false,
-  childrenFromAge: 3,
-  childrenTillAge: 17,
-  languageSelectorVisible: false,
-  redirectUrl: '',
-  redirectUrlNl: '',
-  redirectUrlEn: '',
-  redirectUrlDe: '',
-  redirectUrlFr: '',
-  redirectUrlEs: '',
-  redirectUrlIt: '',
-  showDiscountCode: false,
-  showMonthsAmount: 2,
-  showMonthsInARowAmount: 2
-};
-
-const bookingForm = {
-  adults_from: 18,
-  children: false,
-  children_from: 0,
-  children_til: 12,
-  babies: false,
-  babies_til: 2,
-  showDiscountCode: false,
-  redirectUrl: null,
-  redirectUrlEn: null,
-  redirectUrlNl: null,
-  redirectUrlDe: null,
-  redirectUrlFr: null,
-  redirectUrlEs: null,
-  redirectUrlIt: null
-};
-
 function makeHouse(cancelInsurance: boolean, extra: object = {}) {
   return {
     id: 1,
@@ -110,75 +74,30 @@ function makeHouse(cancelInsurance: boolean, extra: object = {}) {
 }
 
 /**
- * Build a GraphQL response fixture.
- *
- * The Bukazu portal sends all queries as POST requests to the same endpoint.
- * We distinguish queries by the `operationName` field in the POST body and
- * return the appropriate fixture for each query.
+ * Response of GET /portal_api/v1/accommodations/detail — the flat
+ * accommodation payload, without the booking price the fixtures carry for the
+ * price endpoint.
  */
-function makeSingleHouseResponse(house: object) {
-  return {
-    data: {
-      PortalSite: {
-        id: 'E2E',
-        options: { bookingFields: [], bookingForm: {} },
-        bookingFormConfiguration,
-        houses: [house]
-      }
-    }
-  };
-}
-
-function makeBookingPriceResponse(house: object) {
-  return {
-    data: {
-      PortalSite: {
-        id: 'E2E',
-        options: { bookingFields: [], bookingForm },
-        bookingFormConfiguration,
-        max_persons: 10,
-        name: 'E2E Portal',
-        max_bedrooms: 5,
-        max_bathrooms: 3,
-        max_weekprice: 5000,
-        form_submit_text: 'By booking you agree to our',
-        form_submit_button_text: 'Book now',
-        houses: [house]
-      }
-    }
-  };
-}
-
-function makePriceFieldResponse(house: object) {
-  const houseData = house as {
-    booking_price?: { optional_house_costs?: unknown[]; total_price?: number };
+function makeAccommodationDetailResponse(house: object) {
+  const { booking_price: _ignoredBookingPrice, ...accommodation } = house as {
+    booking_price?: unknown;
     [key: string]: unknown;
   };
 
   return {
-    data: {
-      PortalSite: {
-        houses: [
-          {
-            ...houseData,
-            booking_price: {
-              ...(houseData.booking_price ?? {}),
-              total_price: houseData.booking_price?.total_price ?? 1200,
-              optional_house_costs:
-                houseData.booking_price?.optional_house_costs ?? []
-            }
-          }
-        ]
-      }
-    }
+    image_url: null,
+    damage_insurance: false,
+    damage_insurance_required: false,
+    travel_insurance: false,
+    ...accommodation
   };
 }
 
 /**
- * Intercept all GraphQL requests for the duration of a test and serve
- * deterministic fixture responses.
+ * Intercept the REST calls the booking form makes for the duration of a test
+ * and serve deterministic fixture responses.
  */
-async function interceptGraphQL(
+async function interceptApi(
   page: import('@playwright/test').Page,
   house: object
 ) {
@@ -190,35 +109,11 @@ async function interceptGraphQL(
     });
   });
 
-  await page.route(GQL_URL, async (route) => {
-    const postData = route.request().postDataJSON();
-    const query: string = postData?.query ?? '';
-    const operationName: string = postData?.operationName ?? '';
-
-    let body: object;
-
-    if (
-      operationName === 'SingleHouseQuery' ||
-      query.includes('SingleHouseQuery')
-    ) {
-      body = makeSingleHouseResponse(house);
-    } else if (
-      operationName === 'BookingPriceQuery' ||
-      query.includes('BookingPriceQuery')
-    ) {
-      body = makeBookingPriceResponse(house);
-    } else if (query.includes('booking_price')) {
-      // PriceField query
-      body = makePriceFieldResponse(house);
-    } else {
-      // Fallback: return the booking-price fixture so the form can render
-      body = makeBookingPriceResponse(house);
-    }
-
+  await page.route(DETAIL_URL, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(body)
+      body: JSON.stringify(makeAccommodationDetailResponse(house))
     });
   });
 }
@@ -229,7 +124,7 @@ async function interceptGraphQL(
 
 test.describe('Booking form – no cancel insurance', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptGraphQL(page, makeHouse(false));
+    await interceptApi(page, makeHouse(false));
     await page.goto('/calendar.html');
   });
 
@@ -248,7 +143,7 @@ test.describe('Booking form – no cancel insurance', () => {
 
 test.describe('Booking form – with cancel insurance', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptGraphQL(page, makeHouse(true));
+    await interceptApi(page, makeHouse(true));
     await page.goto('/calendar.html');
   });
 
@@ -536,7 +431,7 @@ test.describe('Booking form – modal', () => {
     await interceptPortalConfig(page);
     await interceptAvailability(page);
     await interceptPrice(page, houseWithOptionalCostDescription);
-    await interceptGraphQL(page, houseWithOptionalCostDescription);
+    await interceptApi(page, houseWithOptionalCostDescription);
   });
 
   test('dialog is closed on load', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8377,9 +8377,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8397,9 +8394,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8417,9 +8411,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8437,9 +8428,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8457,9 +8445,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8477,9 +8462,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9308,9 +9290,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9325,9 +9304,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9342,9 +9318,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9359,9 +9332,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9376,9 +9346,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9393,9 +9360,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9410,9 +9374,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9427,9 +9388,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9444,9 +9402,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9461,9 +9416,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14479,9 +14431,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14503,9 +14452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14527,9 +14473,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14551,9 +14494,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/_lib/__tests__/accommodation.test.ts
+++ b/src/_lib/__tests__/accommodation.test.ts
@@ -1,0 +1,156 @@
+import {
+  buildAccommodationDetailUrl,
+  fetchAccommodationDetail,
+  AccommodationDetailError,
+  AccommodationDetail
+} from '../accommodation';
+import { HTTPError } from 'ky';
+
+// Explicit factory mock for the shared HTTP client so tests do not perform real HTTP requests.
+jest.mock('../http_client', () => ({
+  http: { get: jest.fn() }
+}));
+import { http } from '../http_client';
+
+const mockHttp = http as jest.Mocked<typeof http>;
+
+function httpErrorWithStatus(status: number): HTTPError {
+  const fakeResponse = { status } as Response;
+  const fakeRequest = { method: 'GET', url: 'https://example.com' } as Request;
+  return new HTTPError(fakeResponse, fakeRequest, {} as never);
+}
+
+describe('accommodation detail REST client', () => {
+  const baseParams = {
+    apiUrl: 'https://api.bukazu.com/graphql',
+    portalCode: 'TEST',
+    objectCode: 'HOUSE1'
+  };
+
+  describe('buildAccommodationDetailUrl', () => {
+    it('derives the REST origin from the GraphQL api_url and formats the params', () => {
+      const url = new URL(buildAccommodationDetailUrl(baseParams));
+
+      expect(url.origin).toBe('https://api.bukazu.com');
+      expect(url.pathname).toBe('/portal_api/v1/accommodations/detail');
+      expect(url.searchParams.get('portal_code')).toBe('TEST');
+      expect(url.searchParams.get('object_code')).toBe('HOUSE1');
+    });
+
+    it('respects a custom (staging/local) api_url origin', () => {
+      const url = new URL(
+        buildAccommodationDetailUrl({
+          ...baseParams,
+          apiUrl: 'http://localhost:3000/graphql'
+        })
+      );
+
+      expect(url.origin).toBe('http://localhost:3000');
+      expect(url.pathname).toBe('/portal_api/v1/accommodations/detail');
+    });
+
+    it('escapes an object_code containing URL-unsafe characters', () => {
+      const url = new URL(
+        buildAccommodationDetailUrl({ ...baseParams, objectCode: 'HOUSE 1&X' })
+      );
+
+      expect(url.searchParams.get('object_code')).toBe('HOUSE 1&X');
+    });
+  });
+
+  describe('fetchAccommodationDetail', () => {
+    /** Pins the contract: every field the calendar and booking form rely on. */
+    const response: AccommodationDetail = {
+      id: 42,
+      name: 'Villa Test',
+      code: 'HOUSE1',
+      allow_option: true,
+      persons: 6,
+      image_url: 'https://images.bukazu.com/house1.jpg',
+      discounts: '5,10',
+      discounts_info: 'Discount information',
+      house_type: 'house',
+      rental_terms: 'https://example.com/terms.pdf',
+      cancel_insurance: true,
+      damage_insurance: false,
+      damage_insurance_required: false,
+      travel_insurance: true,
+      babies_extra: 2,
+      max_nights: 28,
+      last_minute_days: 14
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls http.get with the correct URL and locale header, returning parsed JSON', async () => {
+      const mockJson = jest.fn().mockResolvedValue(response);
+      (mockHttp.get as jest.Mock).mockReturnValue({ json: mockJson });
+
+      const result = await fetchAccommodationDetail({
+        ...baseParams,
+        locale: 'nl'
+      });
+
+      expect(result).toEqual(response);
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        buildAccommodationDetailUrl(baseParams),
+        { headers: { locale: 'nl' } }
+      );
+    });
+
+    it('throws an AccommodationDetailError flagged as notFound on a 404', async () => {
+      (mockHttp.get as jest.Mock).mockReturnValue({
+        json: jest.fn().mockRejectedValue(httpErrorWithStatus(404))
+      });
+
+      await expect(
+        fetchAccommodationDetail({ ...baseParams, locale: 'nl' })
+      ).rejects.toMatchObject({
+        name: 'AccommodationDetailError',
+        status: 404,
+        notFound: true
+      });
+    });
+
+    it('throws an AccommodationDetailError that is not notFound on other statuses', async () => {
+      (mockHttp.get as jest.Mock).mockReturnValue({
+        json: jest.fn().mockRejectedValue(httpErrorWithStatus(500))
+      });
+
+      await expect(
+        fetchAccommodationDetail({ ...baseParams, locale: 'nl' })
+      ).rejects.toMatchObject({
+        name: 'AccommodationDetailError',
+        status: 500,
+        notFound: false
+      });
+    });
+
+    it('carries the status in the error message', async () => {
+      (mockHttp.get as jest.Mock).mockReturnValue({
+        json: jest.fn().mockRejectedValue(httpErrorWithStatus(503))
+      });
+
+      await expect(
+        fetchAccommodationDetail({ ...baseParams, locale: 'nl' })
+      ).rejects.toThrow('Accommodation detail request failed (503)');
+    });
+
+    it('re-throws non-HTTP errors unchanged', async () => {
+      const networkError = new Error('Network failure');
+      (mockHttp.get as jest.Mock).mockReturnValue({
+        json: jest.fn().mockRejectedValue(networkError)
+      });
+
+      await expect(
+        fetchAccommodationDetail({ ...baseParams, locale: 'nl' })
+      ).rejects.toThrow('Network failure');
+    });
+
+    it('is an instance of Error, so ApiError can render it', () => {
+      expect(new AccommodationDetailError(500)).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/src/_lib/__tests__/queries.test.ts
+++ b/src/_lib/__tests__/queries.test.ts
@@ -4,11 +4,10 @@ import {
   GraphQLSchema,
   DocumentNode
 } from 'graphql';
-import { SINGLE_HOUSE_QUERY, CHECK_DISCOUNT_CODE } from '../gql';
+import { CHECK_DISCOUNT_CODE } from '../gql';
 import introspectionResult from './schema.json';
 
 const allQueries: Array<{ name: string; document: DocumentNode }> = [
-  { name: 'SINGLE_HOUSE_QUERY', document: SINGLE_HOUSE_QUERY },
   { name: 'CHECK_DISCOUNT_CODE', document: CHECK_DISCOUNT_CODE }
 ];
 

--- a/src/_lib/accommodation.ts
+++ b/src/_lib/accommodation.ts
@@ -1,0 +1,99 @@
+import { http } from './http_client';
+import { HTTPError } from 'ky';
+
+/**
+ * The accommodation metadata shared by the detail endpoint and by the price
+ * endpoint's `accommodation` key (include_accommodation=true).
+ */
+export interface Accommodation {
+  id: number;
+  name: string;
+  code: string;
+  allow_option: boolean;
+  persons: number;
+  image_url: string | null;
+  discounts: string | null;
+  discounts_info: string | null;
+  house_type: string;
+  rental_terms: string | null;
+  cancel_insurance: boolean;
+  damage_insurance: boolean;
+  damage_insurance_required: boolean;
+  travel_insurance: boolean;
+  babies_extra: number;
+}
+
+/** Full response of GET /portal_api/v1/accommodations/detail. */
+export interface AccommodationDetail extends Accommodation {
+  /** Longest bookable stay, in nights. */
+  max_nights: number;
+  /** Days before arrival within which a booking counts as last minute. */
+  last_minute_days: number;
+}
+
+/**
+ * A failed accommodation lookup. A 404 means the accommodation is not
+ * published on this portal site, which the calendar renders as "no house
+ * found" rather than as an error.
+ */
+export class AccommodationDetailError extends Error {
+  readonly status: number;
+  readonly notFound: boolean;
+
+  constructor(status: number) {
+    super(`Accommodation detail request failed (${status})`);
+    this.name = 'AccommodationDetailError';
+    this.status = status;
+    this.notFound = status === 404;
+  }
+}
+
+interface FetchAccommodationDetailParams {
+  /** The GraphQL api_url; only its origin is used to reach the REST API. */
+  apiUrl: string;
+  locale: string;
+  portalCode: string;
+  objectCode: string;
+}
+
+const DETAIL_PATH = '/portal_api/v1/accommodations/detail';
+
+/**
+ * Build the REST detail URL by reusing the origin of the configured GraphQL
+ * api_url, so staging/local overrides keep working.
+ */
+export function buildAccommodationDetailUrl({
+  apiUrl,
+  portalCode,
+  objectCode
+}: Omit<FetchAccommodationDetailParams, 'locale'>): string {
+  const url = new URL(DETAIL_PATH, new URL(apiUrl).origin);
+
+  url.search = new URLSearchParams({
+    portal_code: portalCode,
+    object_code: objectCode
+  }).toString();
+
+  return url.toString();
+}
+
+/**
+ * Fetch the metadata of a single accommodation through the REST API.
+ * Replaces the legacy GraphQL SINGLE_HOUSE_QUERY.
+ */
+export async function fetchAccommodationDetail(
+  params: FetchAccommodationDetailParams
+): Promise<AccommodationDetail> {
+  const url = buildAccommodationDetailUrl(params);
+
+  try {
+    return await http
+      .get(url, { headers: { locale: params.locale } })
+      .json<AccommodationDetail>();
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      throw new AccommodationDetailError(error.response.status);
+    }
+    throw error;
+  }
+}

--- a/src/_lib/gql/index.ts
+++ b/src/_lib/gql/index.ts
@@ -1,24 +1,5 @@
 import { gql } from '@apollo/client';
 
-export const SINGLE_HOUSE_QUERY = gql`
-  query PortalSiteSingleHouseQuery($portalCode: ID!, $objectCode: String!) {
-    PortalSite(id: $portalCode) {
-      id
-      houses(house_code: $objectCode) {
-        id
-        code
-        name
-        max_nights
-        last_minute_days
-        discounts
-        discounts_info
-        house_type
-        persons
-      }
-    }
-  }
-`;
-
 export const CHECK_DISCOUNT_CODE = gql`
   mutation CheckDiscountCode($code: String!, $house_code: String!) {
     checkDiscountCode(code: $code, house_code: $house_code) {

--- a/src/_lib/price.ts
+++ b/src/_lib/price.ts
@@ -6,8 +6,18 @@ import {
 } from '../components/CalendarPage/Summary/cost_types';
 import type { AccommodationDetail } from './accommodation';
 
+/**
+ * The REST price endpoint returns optional-cost objects with all CostType
+ * fields plus the extra fields consumed by the booking form.
+ */
+export type RestOptionalCostType = CostType & {
+  max_available: number;
+  method_name: string;
+  description?: string;
+};
+
 /** Full response of GET /portal_api/v1/accommodations/price. */
-export type PriceResponse = PricesType & {
+export type PriceResponse = Omit<PricesType, 'optional_house_costs'> & {
   arrival_date: string;
   departure_date: string;
   arrival_time: string | null;
@@ -20,6 +30,8 @@ export type PriceResponse = PricesType & {
   on_site_house_costs: CostType[];
   person_percentages: unknown;
   night_percentages: unknown;
+  /** Overrides PricesType: REST returns richer items with max_available, method_name, description. */
+  optional_house_costs: RestOptionalCostType[];
   /** Only present when requested with includeAccommodation. */
   accommodation?: AccommodationDetail;
 };

--- a/src/_lib/price.ts
+++ b/src/_lib/price.ts
@@ -4,25 +4,8 @@ import {
   CostType,
   PricesType
 } from '../components/CalendarPage/Summary/cost_types';
+import type { AccommodationDetail } from './accommodation';
 
-/** Accommodation metadata returned when requested with includeAccommodation. */
-export interface PriceAccommodation {
-  id: number;
-  name: string;
-  code: string;
-  allow_option: boolean;
-  persons: number;
-  image_url: string | null;
-  discounts: string | null;
-  discounts_info: string | null;
-  house_type: string;
-  rental_terms: string | null;
-  cancel_insurance: boolean;
-  damage_insurance: boolean;
-  damage_insurance_required: boolean;
-  travel_insurance: boolean;
-  babies_extra: number;
-}
 /** Full response of GET /portal_api/v1/accommodations/price. */
 export type PriceResponse = PricesType & {
   arrival_date: string;
@@ -38,7 +21,7 @@ export type PriceResponse = PricesType & {
   person_percentages: unknown;
   night_percentages: unknown;
   /** Only present when requested with includeAccommodation. */
-  accommodation?: PriceAccommodation;
+  accommodation?: AccommodationDetail;
 };
 
 interface FetchPriceParams {

--- a/src/components/CalendarPage/BookingForm.tsx
+++ b/src/components/CalendarPage/BookingForm.tsx
@@ -6,7 +6,7 @@ import { AppContext } from '../AppContext';
 import { CalendarContext } from './CalendarParts/CalendarContext';
 import { TrackEvent } from '../../_lib/Tracking';
 import type { AppPortalSite } from '../loadPortalSite';
-import type { HouseType } from '../../types';
+import type { HouseType, OptionalHouseCostType } from '../../types';
 
 interface Props {
   portalSite: AppPortalSite;
@@ -39,14 +39,16 @@ function BookingForm({ portalSite }: Props): JSX.Element {
           setPriceError(true);
           return;
         }
-        // The REST response's cost shape is a superset of OptionalHouseCostType.
         setHouse({
           ...price.accommodation,
           booking_price: {
             total_price: price.total_price,
-            optional_house_costs: price.optional_house_costs
+            // The endpoint returns optional costs carrying max_available,
+            // method_name and description, which CostType does not model yet.
+            optional_house_costs:
+              price.optional_house_costs as unknown as OptionalHouseCostType[]
           }
-        } as unknown as HouseType);
+        });
       })
       .catch(() => {
         if (!cancelled) {

--- a/src/components/CalendarPage/BookingForm.tsx
+++ b/src/components/CalendarPage/BookingForm.tsx
@@ -6,7 +6,7 @@ import { AppContext } from '../AppContext';
 import { CalendarContext } from './CalendarParts/CalendarContext';
 import { TrackEvent } from '../../_lib/Tracking';
 import type { AppPortalSite } from '../loadPortalSite';
-import type { HouseType, OptionalHouseCostType } from '../../types';
+import type { HouseType } from '../../types';
 
 interface Props {
   portalSite: AppPortalSite;
@@ -43,10 +43,15 @@ function BookingForm({ portalSite }: Props): JSX.Element {
           ...price.accommodation,
           booking_price: {
             total_price: price.total_price,
-            // The endpoint returns optional costs carrying max_available,
-            // method_name and description, which CostType does not model yet.
-            optional_house_costs:
-              price.optional_house_costs as unknown as OptionalHouseCostType[]
+            optional_house_costs: price.optional_house_costs.map((cost) => ({
+              id: String(cost.id),
+              name: cost.name,
+              method: cost.method,
+              max_available: cost.max_available,
+              amount: cost.amount,
+              method_name: cost.method_name,
+              description: cost.description
+            }))
           }
         });
       })

--- a/src/components/CalendarPage/CalendarParts/GenerateCalendar.tsx
+++ b/src/components/CalendarPage/CalendarParts/GenerateCalendar.tsx
@@ -1,8 +1,10 @@
-import { useQuery } from '@apollo/client';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { t } from '../../../intl';
-import { HouseType } from '../../../types';
-import { SINGLE_HOUSE_QUERY } from '../../../_lib/gql';
+import type { HouseType } from '../../../types';
+import {
+  AccommodationDetailError,
+  fetchAccommodationDetail
+} from '../../../_lib/accommodation';
 import { AppContext } from '../../AppContext';
 import { ApiError } from '../../Error';
 import Loading from '../../icons/loading.svg';
@@ -14,51 +16,94 @@ interface Props {
   portalSite: AppPortalSite;
 }
 
+/**
+ * The outcomes of the accommodation request. `not-found` is a 404, which
+ * replaces the empty houses array the GraphQL query returned for an
+ * accommodation that is not published on this portal site.
+ */
+type CalendarState =
+  | { status: 'loading' }
+  | { status: 'not-found' }
+  | { status: 'error'; error: Error }
+  | { status: 'ready'; house: HouseType };
+
 function GenerateCalendar({ portalSite }: Props): JSX.Element {
-  const { portalCode, objectCode, locale } = useContext(AppContext);
-  const { loading, error, data } = useQuery(SINGLE_HOUSE_QUERY, {
-    variables: { portalCode, objectCode }
-  });
+  const { portalCode, objectCode, locale, apiUrl } = useContext(AppContext);
+  const [state, setState] = useState<CalendarState>({ status: 'loading' });
 
-  TrackEvent({
-    house_code: objectCode,
-    portal_code: portalCode,
-    interaction_type: 'calendar_view',
-    locale: locale
-  });
+  // Sent once per calendar view, not on every render.
+  useEffect(() => {
+    TrackEvent({
+      house_code: objectCode,
+      portal_code: portalCode,
+      interaction_type: 'calendar_view',
+      locale: locale
+    });
+  }, [objectCode, portalCode, locale]);
 
-  if (loading)
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading' });
+
+    fetchAccommodationDetail({ apiUrl, locale, portalCode, objectCode })
+      .then((house) => {
+        if (!cancelled) {
+          setState({ status: 'ready', house });
+        }
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        // A 404 means the accommodation is not on this portal site.
+        if (error instanceof AccommodationDetailError && error.notFound) {
+          setState({ status: 'not-found' });
+          return;
+        }
+        setState({
+          status: 'error',
+          error:
+            error instanceof Error
+              ? error
+              : new Error('The accommodation request failed')
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, locale, portalCode, objectCode]);
+
+  if (state.status === 'loading')
     return (
       <div>
         <Loading />
       </div>
     );
-  if (error) {
+  if (state.status === 'error') {
     return (
       <div>
-        <ApiError errors={error} />
+        <ApiError errors={state.error} />
       </div>
     );
   }
 
-  const Results = data.PortalSite.houses;
   const numberOfMonths = portalSite.bookingFormConfiguration.show_months_amount;
   const numberOfMonthsInARow =
     portalSite.bookingFormConfiguration.show_months_in_a_row_amount;
 
   return (
     <div id="calendar-container">
-      {Results.length === 0 && <div>{t('no_house_found')}</div>}
-      {Results.map((result: HouseType) => (
-        <div key={result.id}>
-          <div className="bup-16">{result.name}</div>
+      {state.status === 'not-found' ? (
+        <div>{t('no_house_found')}</div>
+      ) : (
+        <div>
+          <div className="bup-16">{state.house.name}</div>
           <Calendar
             numberOfMonths={numberOfMonths}
             numberOfMonthsInARow={numberOfMonthsInARow}
-            house={result}
+            house={state.house}
           />
         </div>
-      ))}
+      )}
     </div>
   );
 }

--- a/src/components/CalendarPage/CalendarParts/GenerateCalendar.tsx
+++ b/src/components/CalendarPage/CalendarParts/GenerateCalendar.tsx
@@ -63,7 +63,7 @@ function GenerateCalendar({ portalSite }: Props): JSX.Element {
           error:
             error instanceof Error
               ? error
-              : new Error('The accommodation request failed')
+              : new Error(`The accommodation request failed: ${String(error)}`)
         });
       });
 

--- a/src/components/CalendarPage/CalendarParts/__tests__/Months.test.tsx
+++ b/src/components/CalendarPage/CalendarParts/__tests__/Months.test.tsx
@@ -35,15 +35,18 @@ const house: HouseType = {
   name: 'Test House',
   house_type: 'house',
   persons: 4,
-  bedrooms: 2,
-  bathrooms: 1,
-  minimum_week_price: 1000,
   max_nights: 14,
   babies_extra: 0,
-  city: 'Test City',
-  province: 'Test Province',
-  country_name: 'Test Country',
-  description: 'Test description'
+  allow_option: false,
+  cancel_insurance: false,
+  discounts: '',
+  discounts_info: '',
+  image_url: null,
+  damage_insurance: false,
+  damage_insurance_required: false,
+  travel_insurance: false,
+  last_minute_days: 0,
+  rental_terms: null
 };
 
 function flushPromises(): Promise<void> {

--- a/src/components/CalendarPage/FormCreator.tsx
+++ b/src/components/CalendarPage/FormCreator.tsx
@@ -341,7 +341,7 @@ function FormCreator({ house, PortalSite }: Props): JSX.Element {
                 }}
               >
                 <iframe
-                  src={house.rental_terms}
+                  src={house.rental_terms ?? undefined}
                   width="100%"
                   height="100%"
                   title="Terms"

--- a/src/components/CalendarPage/__tests__/FormCreator.test.tsx
+++ b/src/components/CalendarPage/__tests__/FormCreator.test.tsx
@@ -123,24 +123,22 @@ const mockHouse: HouseType = {
   name: 'Test House',
   house_type: 'house',
   persons: 6,
-  bedrooms: 3,
-  bathrooms: 2,
-  minimum_week_price: 1000,
   max_nights: 14,
   allow_option: false,
   cancel_insurance: false,
   discounts: '',
   discounts_info: '',
   babies_extra: 0,
-  city: 'Amsterdam',
-  province: 'Noord-Holland',
-  country_name: 'Netherlands',
-  description: 'A nice house',
   rental_terms: 'https://example.com/terms',
   booking_price: {
     total_price: 1500,
     optional_house_costs: []
-  } as any
+  } as any,
+  image_url: null,
+  damage_insurance: false,
+  damage_insurance_required: false,
+  travel_insurance: false,
+  last_minute_days: 0
 } as any;
 
 const mockPortalSite: PortalSiteType = {

--- a/src/components/CalendarPage/__tests__/booking-flow.test.tsx
+++ b/src/components/CalendarPage/__tests__/booking-flow.test.tsx
@@ -8,9 +8,8 @@
  * --------
  * • Real components: CalendarWrapper, CalendarPage, GenerateCalendar,
  *   BookingForm, FormCreator, PriceField, Modal, SuccessMessage, CalendarProvider.
- * • Mocked external dependencies: @apollo/client (useQuery),
- *   _lib/gql (returns string constants so useQuery mock can branch on them),
- *   _lib/create_booking, _lib/price, _lib/Tracking, loading SVG icon.
+ * • Mocked external dependencies: _lib/accommodation, _lib/create_booking,
+ *   _lib/price, _lib/Tracking, loading SVG icon.
  * • Mocked heavy sub-components that are already covered by their own unit
  *   tests: Calendar (replaced with simple arrival/departure buttons that drive
  *   the CalendarContext), Guests, Summary, Discount, Insurances, OptionalCosts,
@@ -22,20 +21,18 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import CalendarWrapper from '../CalendarPage';
 import { AppContext } from '../../AppContext';
+import { AccommodationDetailError } from '../../../_lib/accommodation';
 
 // ---------------------------------------------------------------------------
-// Mock @apollo/client – provide a controllable useQuery stub
+// Mock the REST accommodation client (replaces the legacy SINGLE_HOUSE_QUERY).
+// requireActual keeps AccommodationDetailError real, so GenerateCalendar's
+// instanceof check still works.
 // ---------------------------------------------------------------------------
-jest.mock('@apollo/client', () => ({
-  useQuery: jest.fn(),
-  gql: (q: TemplateStringsArray) => q
-}));
-
-// ---------------------------------------------------------------------------
-// Mock gql module with opaque string constants so useQuery mock can branch
-// ---------------------------------------------------------------------------
-jest.mock('../../../_lib/gql', () => ({
-  SINGLE_HOUSE_QUERY: 'SINGLE_HOUSE_QUERY'
+const mockFetchAccommodationDetail = jest.fn();
+jest.mock('../../../_lib/accommodation', () => ({
+  ...jest.requireActual('../../../_lib/accommodation'),
+  fetchAccommodationDetail: (...args: unknown[]) =>
+    mockFetchAccommodationDetail(...args)
 }));
 
 // ---------------------------------------------------------------------------
@@ -196,6 +193,10 @@ const mockHouse = {
   discounts_info: '',
   babies_extra: 0,
   last_minute_days: 0,
+  image_url: null,
+  damage_insurance: false,
+  damage_insurance_required: false,
+  travel_insurance: false,
   rental_terms: 'https://example.com/terms',
   booking_price: {
     total_price: 1500,
@@ -247,15 +248,8 @@ const mockPortalSite = {
   form_submit_button_text: 'Book now'
 } as any;
 
-/** Data returned by SINGLE_HOUSE_QUERY (GenerateCalendar) — house data only. */
-const singleHouseData = {
-  PortalSite: {
-    id: 'TEST',
-    houses: [mockHouse]
-  }
-};
-
-/** Metadata under the `accommodation` key of the REST price response. */
+/** Accommodation metadata as returned by the detail endpoint and under the
+ * `accommodation` key of the price response. */
 const { booking_price: _ignoredBookingPrice, ...mockAccommodation } = mockHouse;
 
 /** Price returned by the REST price endpoint (fetchPrice), used by both
@@ -301,6 +295,8 @@ async function flush() {
 
 /** Simulate clicking on an arrival date then a departure date */
 async function selectDates() {
+  // The calendar only appears once the accommodation request resolved.
+  await flush();
   act(() => {
     (
       container.querySelector('[data-testid="select-arrival"]') as HTMLElement
@@ -347,18 +343,8 @@ beforeEach(() => {
   });
   jest.clearAllMocks();
 
-  const { useQuery } = require('@apollo/client');
-
   mockCreateBooking.mockResolvedValue(bookingResponse);
-
-  // Default useQuery behaviour: return appropriate fixture data per query
-  (useQuery as jest.Mock).mockImplementation((query: string) => {
-    if (query === 'SINGLE_HOUSE_QUERY') {
-      return { data: singleHouseData, loading: false, error: null };
-    }
-    return { data: null, loading: false, error: null };
-  });
-
+  mockFetchAccommodationDetail.mockResolvedValue(mockAccommodation);
   mockFetchPrice.mockResolvedValue(mockPriceResponse);
 });
 
@@ -374,8 +360,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('Booking flow – integration', () => {
-  it('renders the calendar view (GenerateCalendar) on initial load', () => {
+  it('renders the calendar view (GenerateCalendar) on initial load', async () => {
     renderApp();
+    await flush();
 
     expect(
       container.querySelector('[data-testid="mock-calendar"]')
@@ -384,20 +371,80 @@ describe('Booking flow – integration', () => {
     expect(container.querySelector('form.form')).toBeNull();
   });
 
-  it('displays the house name in the calendar view', () => {
+  it('displays the house name in the calendar view', async () => {
     renderApp();
+    await flush();
 
     expect(container.textContent).toContain('Test House');
   });
 
-  it('disables the Calculate button before any date is selected', () => {
+  it('disables the Calculate button before any date is selected', async () => {
     renderApp();
+    await flush();
 
     const calcButton = container.querySelector(
       'button.button'
     ) as HTMLButtonElement | null;
     expect(calcButton).not.toBeNull();
     expect(calcButton!.disabled).toBe(true);
+  });
+
+  it('fetches the accommodation through the REST detail endpoint', async () => {
+    renderApp();
+    await flush();
+
+    expect(mockFetchAccommodationDetail).toHaveBeenCalledWith({
+      apiUrl: 'https://api.bukazu.com/graphql',
+      locale: 'en',
+      portalCode: 'TEST',
+      objectCode: 'HOUSE1'
+    });
+  });
+
+  it('shows the loading indicator until the accommodation resolves', async () => {
+    renderApp();
+
+    expect(container.querySelector('[data-testid="mock-calendar"]')).toBeNull();
+    expect(container.textContent).not.toContain('Test House');
+
+    // Settle the request so the state update stays inside act().
+    await flush();
+  });
+
+  it('shows the api error when the request rejects with a non-Error', async () => {
+    mockFetchAccommodationDetail.mockRejectedValue('boom');
+
+    renderApp();
+    await flush();
+
+    expect(container.querySelector('[data-testid="api-error"]')).not.toBeNull();
+  });
+
+  it('shows "no house found" when the accommodation is not on the portal site', async () => {
+    mockFetchAccommodationDetail.mockRejectedValue(
+      new AccommodationDetailError(404)
+    );
+
+    renderApp();
+    await flush();
+
+    expect(container.querySelector('[data-testid="mock-calendar"]')).toBeNull();
+    expect(container.querySelector('[data-testid="api-error"]')).toBeNull();
+    expect(container.textContent).toContain(
+      'No object found for this combination of PortalCode and ObjectCode'
+    );
+  });
+
+  it('shows the api error when the accommodation request fails', async () => {
+    mockFetchAccommodationDetail.mockRejectedValue(
+      new AccommodationDetailError(500)
+    );
+
+    renderApp();
+    await flush();
+
+    expect(container.querySelector('[data-testid="api-error"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="mock-calendar"]')).toBeNull();
   });
 
   it('enables the Calculate button once arrival and departure dates are selected', async () => {
@@ -508,6 +555,8 @@ describe('Booking flow – integration', () => {
     act(() => {
       (container.querySelector('.return-link') as HTMLElement)?.click();
     });
+    // GenerateCalendar remounts and refetches the accommodation.
+    await flush();
 
     // Calendar should be restored, booking form gone
     expect(

--- a/src/components/CalendarPage/__tests__/booking-form-insurance.test.tsx
+++ b/src/components/CalendarPage/__tests__/booking-form-insurance.test.tsx
@@ -21,10 +21,9 @@ import CalendarWrapper from '../CalendarPage';
 import { AppContext } from '../../AppContext';
 
 // ---------------------------------------------------------------------------
-// Mock @apollo/client
+// Mock @apollo/client – only the discount-code mutation still uses it
 // ---------------------------------------------------------------------------
 jest.mock('@apollo/client', () => ({
-  useQuery: jest.fn(),
   useMutation: jest.fn(() => [
     jest.fn().mockResolvedValue({}),
     { loading: false, error: null, data: null, reset: jest.fn() }
@@ -33,8 +32,15 @@ jest.mock('@apollo/client', () => ({
 }));
 
 jest.mock('../../../_lib/gql', () => ({
-  SINGLE_HOUSE_QUERY: 'SINGLE_HOUSE_QUERY',
-  CREATE_BOOKING_MUTATION: 'CREATE_BOOKING_MUTATION'
+  CHECK_DISCOUNT_CODE: 'CHECK_DISCOUNT_CODE'
+}));
+
+// The calendar loads the accommodation through the REST detail endpoint.
+const mockFetchAccommodationDetail = jest.fn();
+jest.mock('../../../_lib/accommodation', () => ({
+  ...jest.requireActual('../../../_lib/accommodation'),
+  fetchAccommodationDetail: (...args: unknown[]) =>
+    mockFetchAccommodationDetail(...args)
 }));
 
 const mockFetchPrice = jest.fn();
@@ -196,21 +202,14 @@ function makeHouseWithInsurance(cancelInsurance: boolean) {
     discounts_info: '',
     babies_extra: 0,
     last_minute_days: 0,
+    image_url: null,
+    damage_insurance: false,
+    damage_insurance_required: false,
+    travel_insurance: false,
     rental_terms: 'https://example.com/terms',
     booking_price: {
       total_price: 1500,
       optional_house_costs: []
-    }
-  };
-}
-
-function makeSingleHouseData(house: ReturnType<typeof makeHouseWithInsurance>) {
-  return {
-    PortalSite: {
-      id: 'TEST',
-      options: { bookingFields: [], bookingForm: {} },
-      bookingFormConfiguration: mockBookingFormConfiguration,
-      houses: [house]
     }
   };
 }
@@ -244,21 +243,11 @@ let container: HTMLDivElement;
 let root: ReturnType<typeof createRoot>;
 let consoleSpy: jest.SpyInstance;
 
-function setupUseQuery(house: ReturnType<typeof makeHouseWithInsurance>) {
-  const { useQuery } = require('@apollo/client');
-  (useQuery as jest.Mock).mockImplementation((query: string) => {
-    if (query === 'SINGLE_HOUSE_QUERY') {
-      return {
-        data: makeSingleHouseData(house),
-        loading: false,
-        error: null
-      };
-    }
-    return { data: null, loading: false, error: null };
-  });
-  // The booking form now receives the accommodation metadata via the REST
-  // price response (include_accommodation) instead of a separate GraphQL query.
+function setupHouse(house: ReturnType<typeof makeHouseWithInsurance>) {
+  // The calendar reads the accommodation from the detail endpoint; the booking
+  // form gets the same payload under the price response's accommodation key.
   const { booking_price: _ignoredBookingPrice, ...accommodation } = house;
+  mockFetchAccommodationDetail.mockResolvedValue(accommodation);
   mockFetchPrice.mockResolvedValue({
     total_price: 1500,
     currency: 'EUR',
@@ -292,6 +281,8 @@ async function flush() {
 }
 
 async function selectDates() {
+  // The calendar only appears once the accommodation request resolved.
+  await flush();
   act(() => {
     (
       container.querySelector('[data-testid="select-arrival"]') as HTMLElement
@@ -348,7 +339,7 @@ afterEach(() => {
 
 describe('Booking form – cancel_insurance disabled on house', () => {
   it('does not render the insurances section when house.cancel_insurance is false', async () => {
-    setupUseQuery(makeHouseWithInsurance(false));
+    setupHouse(makeHouseWithInsurance(false));
     renderApp();
     await navigateToBookingForm();
 
@@ -356,7 +347,7 @@ describe('Booking form – cancel_insurance disabled on house', () => {
   });
 
   it('renders the booking form without any insurance select', async () => {
-    setupUseQuery(makeHouseWithInsurance(false));
+    setupHouse(makeHouseWithInsurance(false));
     renderApp();
     await navigateToBookingForm();
 
@@ -369,7 +360,7 @@ describe('Booking form – cancel_insurance disabled on house', () => {
 
 describe('Booking form – cancel_insurance enabled on house', () => {
   it('renders the insurances section when house.cancel_insurance is true', async () => {
-    setupUseQuery(makeHouseWithInsurance(true));
+    setupHouse(makeHouseWithInsurance(true));
     renderApp();
     await navigateToBookingForm();
 
@@ -377,7 +368,7 @@ describe('Booking form – cancel_insurance enabled on house', () => {
   });
 
   it('renders the "Insurances" heading', async () => {
-    setupUseQuery(makeHouseWithInsurance(true));
+    setupHouse(makeHouseWithInsurance(true));
     renderApp();
     await navigateToBookingForm();
 
@@ -386,7 +377,7 @@ describe('Booking form – cancel_insurance enabled on house', () => {
   });
 
   it('renders the cancel_insurance select dropdown', async () => {
-    setupUseQuery(makeHouseWithInsurance(true));
+    setupHouse(makeHouseWithInsurance(true));
     renderApp();
     await navigateToBookingForm();
 
@@ -395,7 +386,7 @@ describe('Booking form – cancel_insurance enabled on house', () => {
   });
 
   it('does NOT show the date-of-birth field before any insurance is selected', async () => {
-    setupUseQuery(makeHouseWithInsurance(true));
+    setupHouse(makeHouseWithInsurance(true));
     renderApp();
     await navigateToBookingForm();
 
@@ -404,7 +395,7 @@ describe('Booking form – cancel_insurance enabled on house', () => {
   });
 
   it('shows the date-of-birth field after selecting insurance option "1"', async () => {
-    setupUseQuery(makeHouseWithInsurance(true));
+    setupHouse(makeHouseWithInsurance(true));
     renderApp();
     await navigateToBookingForm();
 
@@ -430,7 +421,7 @@ describe('Booking form – cancel_insurance enabled on house', () => {
   });
 
   it('hides the date-of-birth field after switching back to "None" (value "0")', async () => {
-    setupUseQuery(makeHouseWithInsurance(true));
+    setupHouse(makeHouseWithInsurance(true));
     renderApp();
     await navigateToBookingForm();
 

--- a/src/components/CalendarPage/formParts/__tests__/Guests.test.tsx
+++ b/src/components/CalendarPage/formParts/__tests__/Guests.test.tsx
@@ -22,15 +22,18 @@ const baseHouse: HouseType = {
   name: 'Test House',
   house_type: 'house',
   persons: 4,
-  bedrooms: 2,
-  bathrooms: 1,
-  minimum_week_price: 500,
   max_nights: 14,
   babies_extra: 0,
-  city: 'Amsterdam',
-  province: 'NH',
-  country_name: 'Netherlands',
-  description: ''
+  allow_option: false,
+  cancel_insurance: false,
+  discounts: '',
+  discounts_info: '',
+  image_url: null,
+  damage_insurance: false,
+  damage_insurance_required: false,
+  travel_insurance: false,
+  last_minute_days: 0,
+  rental_terms: null
 } as any;
 
 const baseConfig: BookingFormConfigurationType = {

--- a/src/components/CalendarPage/formParts/__tests__/Validations.test.ts
+++ b/src/components/CalendarPage/formParts/__tests__/Validations.test.ts
@@ -16,15 +16,18 @@ const baseHouse: HouseType = {
   name: 'Test House',
   house_type: 'villa',
   persons: 4,
-  bedrooms: 2,
-  bathrooms: 1,
-  minimum_week_price: 500,
   max_nights: 14,
   babies_extra: 0,
-  city: 'Amsterdam',
-  province: 'NH',
-  country_name: 'Netherlands',
-  description: 'A lovely test house'
+  allow_option: false,
+  cancel_insurance: false,
+  discounts: '',
+  discounts_info: '',
+  image_url: null,
+  damage_insurance: false,
+  damage_insurance_required: false,
+  travel_insurance: false,
+  last_minute_days: 0,
+  rental_terms: null
 };
 
 const baseValues = {

--- a/src/components/SearchPage/__tests__/SingleResult.test.ts
+++ b/src/components/SearchPage/__tests__/SingleResult.test.ts
@@ -1,26 +1,22 @@
 import SingleResult from '../SingleResult';
-import { HouseType, FiltersFormType } from '../../../types';
+import { FiltersFormType } from '../../../types';
+import type { AccommodationResult } from '../../../_lib/accommodations';
 
-const mockResult: HouseType = {
+const mockResult: AccommodationResult = {
   id: 1,
   code: 'HOUSE1',
   name: 'Test House',
   image_url: 'https://example.com/image.jpg',
   house_url: 'https://example.com/house',
-  house_type: 'house',
   persons: 6,
   bedrooms: 3,
   bathrooms: 2,
   minimum_week_price: 1000,
-  max_nights: 14,
   city: 'Amsterdam',
   province: 'Noord-Holland',
   country_name: 'Netherlands',
   description: '<p>A nice house</p>',
-  rating: 4.5,
-  babies_extra: 0,
-  allow_option: false,
-  cancel_insurance: false
+  rating: 4.5
 };
 
 const mockOptions: FiltersFormType = {
@@ -42,7 +38,7 @@ const mockOptions: FiltersFormType = {
 let container: HTMLDivElement;
 
 function renderSingleResult(
-  result: HouseType = mockResult,
+  result: AccommodationResult = mockResult,
   options: FiltersFormType = mockOptions
 ) {
   container.innerHTML = SingleResult({ result, options });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import { PricesType } from './components/CalendarPage/Summary/cost_types';
+import type { AccommodationDetail } from './_lib/accommodation';
 
 export type FiltersFormType = {
   show_city: boolean;
@@ -68,7 +69,13 @@ export type PortalOptions = {
   filtersForm: FiltersFormType;
   bookingFields: object[];
   /** Search-filter fields to render, mapped from the filter-fields REST endpoint. */
-  searchFields?: { id: string; type: string; label: string | null; max?: number; options?: { id: number; name: string }[] }[];
+  searchFields?: {
+    id: string;
+    type: string;
+    label: string | null;
+    max?: number;
+    options?: { id: number; name: string }[];
+  }[];
   /** @deprecated Use PortalSiteType.bookingFormConfiguration instead. */
   bookingForm: BookingFormType;
   colors?: ColorsType;
@@ -115,30 +122,7 @@ export type OptionalHouseCostType = {
   description?: string;
 };
 
-export type HouseType = {
-  id: number;
-  code: string;
-  name: string;
-  image_url?: string;
-  house_url?: string;
-  house_type: string;
-  persons: number;
-  bedrooms: number;
-  bathrooms: number;
-  minimum_week_price: number;
-  max_nights: number;
-  last_minute_days: number;
-  allow_option?: boolean;
-  cancel_insurance?: boolean;
-  discounts?: string;
-  discounts_info?: string;
-  babies_extra: number;
-  city: string;
-  province: string;
-  country_name: string;
-  description: string;
-  rental_terms?: string;
-  rating?: number;
+export type HouseType = AccommodationDetail & {
   booking_price?: {
     total_price: number;
     optional_house_costs: OptionalHouseCostType[];


### PR DESCRIPTION
Closes #484. Depends on BUKAZU/bookingssoftware#1480 — **do not merge until that is deployed.**

## Why

`GenerateCalendar` was the last place in the app running a GraphQL query. `SINGLE_HOUSE_QUERY` selected nine fields of which the calendar branch actually read six (`id`, `name`, `persons`, `house_type`, `max_nights`, `last_minute_days`). This unblocks #486.

There was no dateless REST source for `persons`, `house_type` and `max_nights`, so the sibling PR adds `GET /portal_api/v1/accommodations/detail` and puts `max_nights` + `last_minute_days` on the shared `HouseSerializer` — meaning `price?include_accommodation=true` now returns the same shape, and the booking form needs no extra request.

## What

- **`src/_lib/accommodation.ts`** (new) — `fetchAccommodationDetail` / `buildAccommodationDetailUrl`, following `discount_code.ts`. Exports `Accommodation` (shared with the price endpoint) and `AccommodationDetail`, plus `AccommodationDetailError` carrying `status` / `notFound`.
- **`GenerateCalendar`** — the four outcomes are one discriminated union. A 404 means the accommodation is not published on this portal site and renders `no_house_found`, which is what the empty `houses` array used to mean; every other status renders `ApiError`, so a server failure can no longer be mistaken for an unknown accommodation.
- **`TrackEvent`** moves into its own effect. It fired on every render before, and the added `loading → ready` transition would have sent `calendar_view` twice.
- **`HouseType`** is now `AccommodationDetail & { booking_price? }`. That drops eight fields neither calendar branch ever populated (`bedrooms`, `bathrooms`, `minimum_week_price`, `city`, `province`, `country_name`, `description`, `house_url`, `rating`) — the search page has used `AccommodationResult` since #487 — and `price.ts` reuses the shared type instead of its own `PriceAccommodation`.
- **`BookingForm`** loses `as unknown as HouseType` and spreads `price.accommodation` directly.
- e2e: the GraphQL route interception is gone, replaced by `DETAIL_URL` + `interceptApi` (the old `interceptGraphQL` had been mocking a REST bookings URL since #481). Three unreachable GraphQL fixtures and two dead config fixtures deleted.

`SINGLE_HOUSE_QUERY` is deleted. `gql/index.ts`, `queries.test.ts` and `schema.json` stay until #485 lands; #486 removes Apollo itself.

## One honest caveat

`optional_house_costs` still needs a cast, now narrowed to that single field and commented. The repo describes the same object three incompatible ways — `OptionalHouseCostType` (`id: string`), `CostType` (`id: number`, missing `max_available`/`method_name`) and a third local copy in `OptionalCosts.tsx` — and the real payload matches none of them. Unifying those touches four more components; unrelated debt, filed separately. Net change: a whole-object cast that hid every field mismatch became one documented field cast.

## Tests

- New `src/_lib/__tests__/accommodation.test.ts`: URL building (origin derived from `api_url`, staging override, escaping), locale header, 404 → `notFound`, other statuses, non-HTTP errors re-thrown. 100% coverage on the module.
- `booking-flow` / `booking-form-insurance`: the Apollo `useQuery` mocks are replaced with a `requireActual`-preserving mock of the new module, so `instanceof AccommodationDetailError` still works. Added cases for the loading frame, the 404 branch, the error branch and a non-`Error` rejection. `selectDates()` now flushes first, since the calendar renders asynchronously.
- `SingleResult.test.ts` retyped to `AccommodationResult` (leftover from #487).

```
Test Suites: 75 passed    Tests: 683 passed
```

`tsc --noEmit` clean apart from the pre-existing `src/intl.ts` error; prettier clean on every touched file. Playwright was not run locally (node 18 here) — relying on the CI e2e job.

## Follow-ups

- Unify `CostType` / `OptionalHouseCostType` / `OptionalCosts`' local type against the real payload, killing the last cast.
- Hoist the detail fetch into `CalendarPage` so the booking form does not re-request it.
- `availability.rb` returns `house.name` without `with_request_locale` (pre-existing, backend side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)