### PR TITLE
fix: unbreak master tests and keep betas off the latest dist-tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -64,7 +64,15 @@ jobs:
         run: |
           echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
       - run: npm run build
-      - run: npm publish
+      - name: Publish to npm
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            # Prereleases (e.g. 4.0.0-beta.3) must never take the `latest`
+            # dist-tag, or plain `npm install` would hand consumers a beta.
+            npm publish --tag "$(echo "${VERSION#*-}" | cut -d. -f1)"
+          else
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
       - name: Create GitHub Release
@@ -73,5 +81,6 @@ jobs:
           tag_name: v${{ env.VERSION }}
           name: Release v${{ env.VERSION }}
           generate_release_notes: true
+          prerelease: ${{ contains(env.VERSION, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/__tests__/website.test.tsx
+++ b/src/__tests__/website.test.tsx
@@ -29,17 +29,6 @@ jest.mock('../index', () => (props: object) => (
   <div data-testid="portal" data-props={JSON.stringify(props)} />
 ));
 
-// Mock Apollo and GQL to satisfy transitive imports from index.tsx.
-jest.mock('@apollo/client', () => ({
-  ApolloClient: jest.fn(),
-  InMemoryCache: jest.fn(),
-  ApolloProvider: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  )
-}));
-
-jest.mock('../_lib/gql', () => ({}));
-
 // ---------------------------------------------------------------------------
 // Import the module under test AFTER mocks are set up.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Master is red. `src/__tests__/website.test.tsx` arrived with #324 (IIFE website build) while #499 removed Apollo Client; the two merged in parallel, so the test still mocks `@apollo/client` and `../_lib/gql`, which no longer exist:

```
FAIL src/__tests__/website.test.tsx
  ● Test suite failed to run
    Cannot find module '@apollo/client' from 'src/__tests__/website.test.tsx'
```

691 tests pass; only that suite fails to load. This also blocks `Release npm package`, whose `build` job runs `npm test`.

Separately, the publish job ran a bare `npm publish`. Any prerelease version would have taken the `latest` dist-tag, so a plain `npm install bukazu-portal-react` would hand consumers a beta instead of 3.9.0. (The existing `4.0.0-beta.x` releases avoided this only because they were published by hand.)

## What

- Drop the `@apollo/client` and `../_lib/gql` mocks from `website.test.tsx` — `index.tsx` imports neither any more.
- Derive the npm dist-tag from the version's prerelease label: `4.0.0-beta.3` publishes as `--tag beta`, stable versions still publish as `latest`.
- Mark prerelease GitHub releases with `prerelease: true`.

## Testing

Jest cannot run on this machine (node 18 locally, repo needs 24 — Babel 8 is ESM-only), so CI is the check here. Expecting `Tests` green on 24.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)