### PR TITLE
fix: make the website bundle actually work in a browser

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,6 +31,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present
+      - run: npm run verify:website
       - run: npm test
       - name: Coverage comment
         if: github.event_name == 'pull_request' && matrix.node-version == '24.x'
@@ -57,6 +58,9 @@ jobs:
           node-version: 24.x
           cache: 'npm'
       - run: npm ci
+      - name: Build the bundles the website e2e spec loads
+        run: npm run build
+      - run: npm run verify:website
       - name: Run Playwright e2e tests
         run: npm run test:e2e
       - name: Upload Playwright report
@@ -89,5 +93,5 @@ jobs:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           install-script: 'npm ci'
           build-script: 'npm run build'
-          pattern: './build/portal.{es,umd}.js'
+          pattern: './build/portal.{es,website}.js'
           strip-hash: '\.[a-f0-9]{8}\.'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -63,7 +63,14 @@ jobs:
       - name: Get version
         run: |
           echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - run: npm run build
+      - name: Build (bakes the Sentry DSN into the website bundle)
+        run: npm run build
+        env:
+          BUKAZU_SENTRY_DSN: ${{ vars.BUKAZU_SENTRY_DSN }}
+      - name: Verify the website bundle
+        run: npm run verify:website
+        env:
+          BUKAZU_SENTRY_DSN: ${{ vars.BUKAZU_SENTRY_DSN }}
       - name: Publish to npm
         run: |
           if [[ "$VERSION" == *-* ]]; then

--- a/README.md
+++ b/README.md
@@ -100,14 +100,15 @@ Render the reviews page for a specific property by passing `objectCode` together
 
 ## Direct website usage (no bundler required)
 
-If you are not using a JavaScript bundler or a React application, you can use the self-contained **website build** instead. This single file includes React and all other dependencies — just drop two files into your page and add a `<div>` with the right attributes.
+If you are not using a JavaScript bundler or a React application, you can use the self-contained **website build** instead. This single file includes React, every other dependency, and the stylesheet — drop it into your page and add a `<div>` with the right attributes.
 
-### 1. Download or reference the files
+### 1. Download or reference the file
 
-After installing the package, copy the files from the package (or reference them from a CDN/local path):
+After installing the package, copy the file from the package (or reference it from a CDN/local path):
 
 - `node_modules/bukazu-portal-react/build/portal.website.js`
-- `node_modules/bukazu-portal-react/build/portal.website.css`
+
+The bundle injects its own `<style>` element, so no stylesheet link is required. A companion `node_modules/bukazu-portal-react/build/portal.website.css` is published as well, for pages whose Content-Security-Policy forbids inline styles (`style-src` without `'unsafe-inline'`).
 
 ### 2. Add a host element
 
@@ -118,8 +119,13 @@ Place a `<div class="bukazu-app">` with the following HTML attributes wherever y
 | `portal-code` | ✅ | Your Bukazu portal identifier |
 | `object-code` | — | Property code (omit for the Search module) |
 | `page` | — | Set to `"reviews"` for the Reviews module |
-| `language` | — | Locale: `en` \| `nl` \| `de` \| `fr` \| `es` \| `it` (default: `en`) |
+| `language` | — | Locale: `en` \| `nl` \| `de` \| `fr` \| `es` \| `it`, or a full BCP-47 tag such as `nl-NL` (default: `en`) |
 | `filters` | — | JSON-encoded filters object (see filter keys in the props table below) |
+| `sentry-dsn` | — | Sentry DSN for error reporting. Defaults to the DSN baked into the bundle; pass `off` to disable reporting |
+
+The host element is found by the `bukazu-app` class. Pages that carry no such
+element fall back to a single element with `id="bukazu-app"`, which is what older
+embed snippets use.
 
 ### 3. Include the script and stylesheet
 
@@ -129,7 +135,6 @@ Place a `<div class="bukazu-app">` with the following HTML attributes wherever y
   <head>
     <meta charset="UTF-8" />
     <title>My website</title>
-    <link rel="stylesheet" href="portal.website.css" />
   </head>
   <body>
 
@@ -151,7 +156,9 @@ Place a `<div class="bukazu-app">` with the following HTML attributes wherever y
 </html>
 ```
 
-The script automatically initialises every `.bukazu-app` element it finds on the page when the DOM is ready. Multiple portals on the same page are supported.
+The script automatically initialises every `.bukazu-app` element it finds on the page when the DOM is ready. Multiple portals on the same page are supported, and loading the bundle twice is harmless — it re-renders the existing portals rather than mounting duplicates.
+
+For advanced use the bundle exposes `BukazuPortal.init()`, `BukazuPortal.mountPortal(element)` and `BukazuPortal.version` as globals, so you can mount a portal into an element you inserted after page load.
 
 ---
 

--- a/e2e/fixtures/website-double.html
+++ b/e2e/fixtures/website-double.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Website build fixture – loaded twice</title>
+  </head>
+  <body>
+    <!--
+      Some pages end up with a cached inline copy of the bundle alongside the
+      CDN copy. Loading it twice must still produce one <style> element and one
+      mounted portal.
+    -->
+    <div class="bukazu-app" portal-code="2fb81a2d" language="nl"></div>
+
+    <script src="/build/portal.website.js"></script>
+    <script src="/build/portal.website.js"></script>
+  </body>
+</html>

--- a/e2e/fixtures/website-id-only.html
+++ b/e2e/fixtures/website-id-only.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Website build fixture – id-only host</title>
+  </head>
+  <body>
+    <!-- Older embed snippets identify the host element by id alone. -->
+    <div id="bukazu-app" portal-code="2fb81a2d" language="nl"></div>
+
+    <script src="/build/portal.website.js"></script>
+  </body>
+</html>

--- a/e2e/fixtures/website-sentry.html
+++ b/e2e/fixtures/website-sentry.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Website build fixture – Sentry reporting</title>
+  </head>
+  <body>
+    <!--
+      portal-code is omitted on purpose: the Portal component then renders an
+      integration error and reports it, which is what exercises the DSN wiring.
+      The DSN points at a host the test intercepts, never at a real project.
+    -->
+    <div
+      class="bukazu-app"
+      sentry-dsn="https://e2e@o0.ingest.sentry.io/1"
+      language="nl"
+    ></div>
+
+    <script src="/build/portal.website.js"></script>
+  </body>
+</html>

--- a/e2e/fixtures/website.html
+++ b/e2e/fixtures/website.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Website build fixture</title>
+    <!--
+      Deliberately no <link rel="stylesheet">: the bundle must inject its own
+      styles. A full BCP-47 tag is used to prove the language attribute reaches
+      Portal's locale normalisation.
+    -->
+  </head>
+  <body>
+    <div
+      class="bukazu-app"
+      id="bukazu-app"
+      portal-code="2fb81a2d"
+      language="nl-NL"
+    ></div>
+
+    <script src="/build/portal.website.js"></script>
+  </body>
+</html>

--- a/e2e/website-bundle.spec.ts
+++ b/e2e/website-bundle.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * End-to-end coverage for the built `portal.website.js` bundle.
+ *
+ * The unit tests exercise `src/website.tsx` with React and the stylesheet
+ * mocked out, so they cannot see the properties that only exist after Vite has
+ * run: the IIFE wrapper, the global name, the injected stylesheet, and the fact
+ * that React is bundled in. Those are what this spec covers.
+ *
+ * The fixtures are served by `scripts/serve-static.mjs` (see the second
+ * `webServer` entry in playwright.config.ts), because the Vite dev server would
+ * transform the bundle instead of serving it verbatim.
+ */
+
+const STATIC_BASE = 'http://localhost:4174';
+const STYLE_ID = 'bukazu-portal-styles';
+
+/** Keeps the tests independent of the live API. */
+async function stubApi(page: Page): Promise<void> {
+  await page.route('**/api.bukazu.com/**', (route) => route.abort());
+}
+
+test.describe('portal.website.js', () => {
+  test('injects its stylesheet without a link tag', async ({ page }) => {
+    await stubApi(page);
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website.html`);
+
+    const styles = page.locator(`style#${STYLE_ID}`);
+    await expect(styles).toHaveCount(1);
+
+    // The page itself loads no stylesheet, so the portal CSS can only come
+    // from the bundle.
+    await expect(page.locator('link[rel="stylesheet"]')).toHaveCount(0);
+
+    const cssLength = await styles.evaluate(
+      (element) => element.textContent?.length ?? 0
+    );
+    expect(cssLength).toBeGreaterThan(5000);
+  });
+
+  test('stamps the injected style element with the package version', async ({
+    page
+  }) => {
+    await stubApi(page);
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website.html`);
+
+    const version = await page
+      .locator(`style#${STYLE_ID}`)
+      .getAttribute('data-bukazu-version');
+    const exposedVersion = await page.evaluate(
+      () =>
+        (window as unknown as { BukazuPortal: { version: string } })
+          .BukazuPortal.version
+    );
+
+    expect(version).toBe(exposedVersion);
+  });
+
+  test('the injected styles are applied by the browser', async ({ page }) => {
+    await stubApi(page);
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website.html`);
+
+    const hasPortalRules = await page.evaluate(() =>
+      Array.from(document.styleSheets).some((sheet) => {
+        try {
+          return Array.from(sheet.cssRules).some((rule) =>
+            rule.cssText.includes('#bukazu-app')
+          );
+        } catch {
+          return false;
+        }
+      })
+    );
+
+    expect(hasPortalRules).toBe(true);
+  });
+
+  test('exposes init, mountPortal and version on the global', async ({
+    page
+  }) => {
+    await stubApi(page);
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website.html`);
+
+    const api = await page.evaluate(() => {
+      const globalApi = (window as unknown as { BukazuPortal: object })
+        .BukazuPortal;
+      return Object.keys(globalApi).sort();
+    });
+
+    expect(api).toEqual(
+      expect.arrayContaining(['init', 'mountPortal', 'version'])
+    );
+  });
+
+  test('mounts the portal, so React is bundled in', async ({ page }) => {
+    await stubApi(page);
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website.html`);
+
+    // Rendering anything at all proves React and react-dom are inside the
+    // bundle: the fixture loads no other script.
+    await expect(page.locator('#bukazu-app > *')).not.toHaveCount(0);
+  });
+
+  test('mounts on an id-only host element', async ({ page }) => {
+    await stubApi(page);
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website-id-only.html`);
+
+    await expect(page.locator('#bukazu-app > *')).not.toHaveCount(0);
+  });
+
+  test('loading the bundle twice injects one style and mounts once', async ({
+    page
+  }) => {
+    await stubApi(page);
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website-double.html`);
+
+    await expect(page.locator(`style#${STYLE_ID}`)).toHaveCount(1);
+    expect(
+      consoleErrors.filter((error) => error.includes('createRoot'))
+    ).toHaveLength(0);
+  });
+
+  test('reports errors to the Sentry DSN from the attribute', async ({
+    page
+  }) => {
+    await stubApi(page);
+    let envelopeSent = false;
+    await page.route('**/*.ingest.sentry.io/**', (route) => {
+      envelopeSent = true;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{}'
+      });
+    });
+
+    await page.goto(`${STATIC_BASE}/e2e/fixtures/website-sentry.html`);
+
+    await expect.poll(() => envelopeSent, { timeout: 15000 }).toBe(true);
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,12 @@ import type { Config } from 'jest';
 const config: Config = {
   verbose: true,
   testEnvironment: 'jsdom',
+  // Constants that `vite.website.config.ts` supplies through `define`; Jest has
+  // no equivalent, so they are declared as globals here.
+  globals: {
+    __SENTRY_DSN__: '',
+    __PORTAL_VERSION__: '0.0.0-test'
+  },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '\\.css$': '<rootDir>/src/__mocks__/fileMock.ts',

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "test:watch": "jest --watch",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "build": "npm run countries:pack && vite build && vite build --config vite.website.config.ts",
+    "build": "npm run countries:pack && vite build && npm run build:website",
     "build:analyze": "npm run countries:pack && cross-env ANALYZE=true vite build",
-    "dev": "vite"
+    "dev": "vite",
+    "build:website": "vite build --config vite.website.config.ts",
+    "verify:website": "node ./scripts/verify-website-bundle.mjs"
   },
   "author": "Bob van Oorschot",
   "license": "MIT",
@@ -72,7 +74,10 @@
     "./index.css": "./build/index.css",
     "./build/index.css": "./build/index.css",
     "./portal.website.js": "./build/portal.website.js",
-    "./portal.website.css": "./build/portal.website.css"
+    "./portal.website.css": "./build/portal.website.css",
+    "./build/portal.website.js": "./build/portal.website.js",
+    "./build/portal.website.css": "./build/portal.website.css",
+    "./package.json": "./package.json"
   },
   "sideEffects": [
     "*.css"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,9 +33,21 @@ export default defineConfig({
     }
   ],
   /* Run local dev server before starting the tests */
-  webServer: {
-    command: 'npm run dev -- --port 5173 --strictPort',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI
-  }
+  webServer: [
+    {
+      command: 'npm run dev -- --port 5173 --strictPort',
+      url: 'http://localhost:5173',
+      reuseExistingServer: !process.env.CI
+    },
+    /*
+     * Serves the repository as static files so website-bundle.spec.ts can load
+     * the built build/portal.website.js through a plain <script> tag, the way an
+     * embedder does. Requires `npm run build:website` to have run.
+     */
+    {
+      command: 'node ./scripts/serve-static.mjs --port 4174',
+      url: 'http://localhost:4174/e2e/fixtures/website.html',
+      reuseExistingServer: !process.env.CI
+    }
+  ]
 });

--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -1,0 +1,69 @@
+/**
+ * Minimal static file server for the end-to-end tests.
+ *
+ * The website bundle has to be exercised the way an embedder loads it: a plain
+ * `<script>` tag pointing at the built file. The Vite dev server would push it
+ * through its transform pipeline instead, so the e2e run serves the repository
+ * as-is from here.
+ *
+ * Usage: node ./scripts/serve-static.mjs [--port 4174]
+ */
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const portArgIndex = process.argv.indexOf('--port');
+const port =
+  portArgIndex === -1
+    ? 4174
+    : Number.parseInt(process.argv[portArgIndex + 1], 10);
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.woff2': 'font/woff2',
+  '.msgpack': 'application/octet-stream'
+};
+
+// Fail loudly rather than letting Playwright wait on a server that can only
+// serve 404s for the file under test.
+const bundle = join(root, 'build/portal.website.js');
+try {
+  await stat(bundle);
+} catch {
+  console.error(
+    `build/portal.website.js not found — run "npm run build:website" first`
+  );
+  process.exit(1);
+}
+
+createServer(async (request, response) => {
+  const requestPath = new URL(request.url ?? '/', 'http://localhost').pathname;
+  // `normalize` collapses any `..` segments before the join, so requests cannot
+  // escape the repository root.
+  const filePath = join(root, normalize(requestPath));
+
+  try {
+    const body = await readFile(filePath);
+    response.writeHead(200, {
+      'content-type':
+        MIME_TYPES[extname(filePath)] ?? 'application/octet-stream',
+      'cache-control': 'no-store'
+    });
+    response.end(body);
+  } catch {
+    response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end(`not found: ${requestPath}`);
+  }
+}).listen(port, () => {
+  console.log(`static server listening on http://localhost:${port}`);
+});

--- a/scripts/verify-website-bundle.mjs
+++ b/scripts/verify-website-bundle.mjs
@@ -1,0 +1,100 @@
+/**
+ * Gate that stops a broken website bundle from being published.
+ *
+ * `portal.website.js` is consumed as a bare `<script>` tag by embedders who
+ * have no build step, so a bundle that lost its inlined stylesheet — or its
+ * Sentry DSN — is a silent production regression rather than a build failure.
+ * This script asserts the properties that no unit test can see, because they
+ * only exist after Vite has run.
+ *
+ * Usage: node ./scripts/verify-website-bundle.mjs
+ */
+import { readFile, stat } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const jsPath = resolve(root, 'build/portal.website.js');
+const cssPath = resolve(root, 'build/portal.website.css');
+
+const failures = [];
+
+function check(condition, message) {
+  if (!condition) {
+    failures.push(message);
+  }
+}
+
+async function sizeOf(path) {
+  try {
+    return (await stat(path)).size;
+  } catch {
+    return 0;
+  }
+}
+
+const jsSize = await sizeOf(jsPath);
+const cssSize = await sizeOf(cssPath);
+
+check(
+  jsSize > 0,
+  `build/portal.website.js is missing or empty — run "npm run build:website"`
+);
+check(cssSize > 0, 'build/portal.website.css is missing or empty');
+
+if (jsSize > 0) {
+  const js = await readFile(jsPath, 'utf8');
+  const { version } = require('../package.json');
+
+  check(
+    js.includes('bukazu-portal-styles'),
+    'the bundle does not inject its stylesheet (no "bukazu-portal-styles" marker)'
+  );
+  check(
+    js.includes('#bukazu-app'),
+    'the bundle does not contain the portal stylesheet (no "#bukazu-app" rules)'
+  );
+  // A `<script>` tag has no bundler behind it to define `process`, so any
+  // surviving reference throws "process is not defined" and the portal never
+  // mounts. Vite does not substitute these in library mode by default.
+  check(
+    !js.includes('process.env'),
+    'the bundle still references process.env, which throws in a browser'
+  );
+  check(
+    js.includes(`data-bukazu-version","${version}"`) ||
+      js.includes(`data-bukazu-version",'${version}'`),
+    `the injected style element is not stamped with version ${version}`
+  );
+
+  // The DSN is only baked in when the environment supplies one, so this is a
+  // conditional check: locally an empty DSN is expected, in the publish
+  // workflow an empty DSN means production lost its error reporting.
+  if (process.env.BUKAZU_SENTRY_DSN) {
+    check(
+      js.includes(process.env.BUKAZU_SENTRY_DSN),
+      'BUKAZU_SENTRY_DSN is set but the bundle does not contain it'
+    );
+  }
+}
+
+const kb = (bytes) => `${(bytes / 1024).toFixed(1)} KB`;
+console.log(`portal.website.js  ${kb(jsSize)}`);
+console.log(`portal.website.css ${kb(cssSize)}`);
+console.log(
+  process.env.BUKAZU_SENTRY_DSN
+    ? 'Sentry DSN: baked in'
+    : 'Sentry DSN: not set (BUKAZU_SENTRY_DSN unset)'
+);
+
+if (failures.length > 0) {
+  console.error('\nwebsite bundle verification failed:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nwebsite bundle OK');

--- a/src/__tests__/website.test.tsx
+++ b/src/__tests__/website.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../index', () => (props: object) => (
 // Import the module under test AFTER mocks are set up.
 // ---------------------------------------------------------------------------
 
-import { mountPortal, init } from '../website';
+import { mountPortal, init, version } from '../website';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,6 +62,7 @@ function lastPortalProps(): Record<string, unknown> {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  document.body.innerHTML = '';
 });
 
 describe('mountPortal – attribute parsing', () => {
@@ -105,9 +106,30 @@ describe('mountPortal – attribute parsing', () => {
 
     expect(lastPortalProps().pageType).toBeUndefined();
   });
+
+  // The WordPress plugin renders page="" and object-code="" for the calendar
+  // module, so a present-but-empty attribute must stay an empty string rather
+  // than becoming undefined.
+  it('keeps present-but-empty page and object-code attributes as empty strings', () => {
+    const el = makeElement({
+      'portal-code': 'X',
+      'object-code': '',
+      page: ''
+    });
+    act(() => {
+      mountPortal(el);
+    });
+
+    const props = lastPortalProps();
+    expect(props.objectCode).toBe('');
+    expect(props.pageType).toBe('');
+  });
 });
 
-describe('mountPortal – locale validation', () => {
+describe('mountPortal – locale handling', () => {
+  // The language attribute is handed to Portal verbatim; normalisation (BCP-47
+  // tags, casing, the fallback to English) is Portal's job and is covered by
+  // src/_lib/__tests__/locale.test.ts.
   it.each(['en', 'nl', 'de', 'fr', 'es', 'it'])(
     'passes supported locale "%s" through unchanged',
     (locale) => {
@@ -120,22 +142,105 @@ describe('mountPortal – locale validation', () => {
     }
   );
 
-  it('falls back to "en" when the language attribute is absent', () => {
+  it.each(['nl-NL', 'de_DE', 'EN'])(
+    'passes the full locale tag "%s" through for Portal to normalise',
+    (locale) => {
+      const el = makeElement({ 'portal-code': 'X', language: locale });
+      act(() => {
+        mountPortal(el);
+      });
+
+      expect(lastPortalProps().locale).toBe(locale);
+    }
+  );
+
+  it('passes undefined when the language attribute is absent', () => {
     const el = makeElement({ 'portal-code': 'X' });
     act(() => {
       mountPortal(el);
     });
 
-    expect(lastPortalProps().locale).toBe('en');
+    expect(lastPortalProps().locale).toBeUndefined();
   });
 
-  it('falls back to "en" for an unrecognised language value', () => {
+  it('passes an unrecognised language value through for Portal to reject', () => {
     const el = makeElement({ 'portal-code': 'X', language: 'xx' });
     act(() => {
       mountPortal(el);
     });
 
-    expect(lastPortalProps().locale).toBe('en');
+    expect(lastPortalProps().locale).toBe('xx');
+  });
+});
+
+describe('mountPortal – Sentry DSN', () => {
+  const BAKED_DSN = 'https://baked@o0.ingest.sentry.io/1';
+  const originalDsn = __SENTRY_DSN__;
+
+  function setBakedDsn(dsn: string): void {
+    (globalThis as unknown as { __SENTRY_DSN__: string }).__SENTRY_DSN__ = dsn;
+  }
+
+  afterEach(() => {
+    setBakedDsn(originalDsn);
+  });
+
+  it('prefers the sentry-dsn attribute over the baked-in DSN', () => {
+    setBakedDsn(BAKED_DSN);
+    const el = makeElement({
+      'portal-code': 'X',
+      'sentry-dsn': 'https://attr@o0.ingest.sentry.io/2'
+    });
+    act(() => {
+      mountPortal(el);
+    });
+
+    expect(lastPortalProps().sentryDsn).toBe(
+      'https://attr@o0.ingest.sentry.io/2'
+    );
+  });
+
+  it('uses the baked-in DSN when the attribute is absent', () => {
+    setBakedDsn(BAKED_DSN);
+    const el = makeElement({ 'portal-code': 'X' });
+    act(() => {
+      mountPortal(el);
+    });
+
+    expect(lastPortalProps().sentryDsn).toBe(BAKED_DSN);
+  });
+
+  it('uses the baked-in DSN when the attribute is present but empty', () => {
+    setBakedDsn(BAKED_DSN);
+    const el = makeElement({ 'portal-code': 'X', 'sentry-dsn': '' });
+    act(() => {
+      mountPortal(el);
+    });
+
+    expect(lastPortalProps().sentryDsn).toBe(BAKED_DSN);
+  });
+
+  it.each(['off', 'none'])(
+    'disables reporting when sentry-dsn is "%s"',
+    (value) => {
+      setBakedDsn(BAKED_DSN);
+      const el = makeElement({ 'portal-code': 'X', 'sentry-dsn': value });
+      act(() => {
+        mountPortal(el);
+      });
+
+      expect(lastPortalProps().sentryDsn).toBeUndefined();
+    }
+  );
+
+  it('passes undefined when neither the attribute nor the baked DSN is set', () => {
+    setBakedDsn('');
+    const el = makeElement({ 'portal-code': 'X' });
+    act(() => {
+      mountPortal(el);
+    });
+
+    expect(lastPortalProps().sentryDsn).toBeUndefined();
   });
 });
 
@@ -224,12 +329,55 @@ describe('init', () => {
     el2.remove();
   });
 
-  it('does nothing when there are no .bukazu-app elements', () => {
+  it('does nothing when the document has no host element at all', () => {
     act(() => {
       init();
     });
 
     expect(mockCreateRoot).not.toHaveBeenCalled();
+  });
+
+  it('falls back to #bukazu-app when no element carries the class', () => {
+    const el = makeElement({ 'portal-code': 'BY_ID' });
+    el.id = 'bukazu-app';
+    document.body.appendChild(el);
+
+    act(() => {
+      init();
+    });
+
+    expect(mockCreateRoot).toHaveBeenCalledWith(el);
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores #bukazu-app when class-based hosts exist', () => {
+    const byClass = makeElement({ 'portal-code': 'BY_CLASS' });
+    byClass.className = 'bukazu-app';
+    const byId = makeElement({ 'portal-code': 'BY_ID' });
+    byId.id = 'bukazu-app';
+    document.body.appendChild(byClass);
+    document.body.appendChild(byId);
+
+    act(() => {
+      init();
+    });
+
+    expect(mockCreateRoot).toHaveBeenCalledWith(byClass);
+    expect(mockCreateRoot).not.toHaveBeenCalledWith(byId);
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts an element that carries both the class and the id only once', () => {
+    const el = makeElement({ 'portal-code': 'BOTH' });
+    el.className = 'bukazu-app';
+    el.id = 'bukazu-app';
+    document.body.appendChild(el);
+
+    act(() => {
+      init();
+    });
+
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -247,5 +395,104 @@ describe('mountPortal – double-mount prevention', () => {
 
     expect(mockCreateRoot).toHaveBeenCalledTimes(1);
     expect(mockRender).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: version export and the cross-instance root registry
+// ---------------------------------------------------------------------------
+
+describe('version', () => {
+  it('exposes the version baked in at build time', () => {
+    expect(version).toBe(__PORTAL_VERSION__);
+  });
+});
+
+describe('root registry', () => {
+  it('is shared across module instances so a double-loaded bundle mounts once', () => {
+    const el = makeElement({ 'portal-code': 'X' });
+    act(() => {
+      mountPortal(el);
+    });
+
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const reloaded = require('../website') as {
+      mountPortal: typeof mountPortal;
+    };
+    act(() => {
+      reloaded.mountPortal(el);
+    });
+
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+    expect(mockRender).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: auto-initialisation on import
+// ---------------------------------------------------------------------------
+
+describe('auto-initialisation', () => {
+  /** Overrides the read-only `document.readyState` getter for one test. */
+  function withReadyState(state: DocumentReadyState, run: () => void): void {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'readyState'
+    );
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      get: () => state
+    });
+    try {
+      run();
+    } finally {
+      delete (document as unknown as Record<string, unknown>).readyState;
+      if (descriptor) {
+        Object.defineProperty(Document.prototype, 'readyState', descriptor);
+      }
+    }
+  }
+
+  it('waits for DOMContentLoaded when the document is still loading', () => {
+    const addEventListener = jest.spyOn(document, 'addEventListener');
+
+    withReadyState('loading', () => {
+      jest.resetModules();
+      require('../website');
+    });
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      'DOMContentLoaded',
+      expect.any(Function)
+    );
+    expect(mockCreateRoot).not.toHaveBeenCalled();
+
+    // The registered listener is the real `init`, so firing it mounts.
+    const listener = addEventListener.mock.calls.find(
+      ([type]) => type === 'DOMContentLoaded'
+    )?.[1] as () => void;
+    const el = makeElement({ 'portal-code': 'DEFERRED' });
+    el.className = 'bukazu-app';
+    document.body.appendChild(el);
+    act(() => {
+      listener();
+    });
+
+    expect(mockCreateRoot).toHaveBeenCalledWith(el);
+    addEventListener.mockRestore();
+  });
+
+  it('mounts immediately when the document is already parsed', () => {
+    const el = makeElement({ 'portal-code': 'IMMEDIATE' });
+    el.className = 'bukazu-app';
+    document.body.appendChild(el);
+
+    withReadyState('complete', () => {
+      jest.resetModules();
+      require('../website');
+    });
+
+    expect(mockCreateRoot).toHaveBeenCalledWith(el);
   });
 });

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,6 +2,16 @@ interface Window {
   __localeId__?: string;
 }
 
+/**
+ * Sentry DSN baked into the website build (`vite.website.config.ts`).
+ * An empty string means the bundle reports nothing unless an embedder supplies
+ * a `sentry-dsn` attribute.
+ */
+declare const __SENTRY_DSN__: string;
+
+/** Package version baked into the website build. */
+declare const __PORTAL_VERSION__: string;
+
 declare module '*.css' {
   const content: Record<string, string>;
   export default content;

--- a/src/website.tsx
+++ b/src/website.tsx
@@ -2,17 +2,23 @@
  * Website entry point for the Bukazu Portal.
  *
  * This module is compiled into a self-contained IIFE bundle (`portal.website.js`)
- * that includes React and all other dependencies.  Drop it into any HTML page
- * together with the companion CSS file and it will automatically mount a Portal
- * on every element that carries the `bukazu-app` class.
+ * that includes React, all other dependencies, and the stylesheet.  Drop it into
+ * any HTML page and it will automatically mount a Portal on every element that
+ * carries the `bukazu-app` class.  When no such element exists it falls back to
+ * `#bukazu-app`, which is what older embed snippets use.
  *
  * Attribute API (set on the host element):
  *   portal-code  – required  – portal identifier (empty string shows an error state)
  *   object-code  – optional  – object/property identifier (omit for search)
  *   page         – optional  – page type override
- *   language     – optional  – locale: en | nl | de | fr | es | it (default: en)
+ *   language     – optional  – locale, either a bare code (`nl`) or a full BCP-47
+ *                              tag (`nl-NL`); unsupported languages fall back to
+ *                              English
  *   filters      – optional  – JSON-encoded filters object; invalid JSON is silently
  *                              ignored and an empty object is used instead
+ *   sentry-dsn   – optional  – Sentry DSN for error reporting; defaults to the DSN
+ *                              baked into the bundle at build time. Pass `off` (or
+ *                              `none`) to disable reporting entirely.
  *
  * Example:
  *   <div class="bukazu-app"
@@ -20,8 +26,11 @@
  *        object-code="YOUR_OBJECT_CODE"
  *        language="en">
  *   </div>
- *   <link  rel="stylesheet" href="portal.website.css">
  *   <script src="portal.website.js"></script>
+ *
+ * The bundle injects its own `<style>` element, so no stylesheet link is needed.
+ * Embedders whose Content-Security-Policy forbids inline styles can instead load
+ * the companion `portal.website.css` through a `<link>` tag.
  *
  * For advanced usage, the `init` and `mountPortal` functions are also exposed
  * on the `BukazuPortal` global so you can call them manually from your own
@@ -33,13 +42,29 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 
 import Portal from './index';
-import { LocaleType } from './types';
 import { FiltersType } from './components/SearchPage/filters/filter_types';
 
 const CLASS_NAME = 'bukazu-app';
+const ELEMENT_ID = 'bukazu-app';
 
-/** Cache of already-created React roots, keyed by host element. */
-const roots = new WeakMap<HTMLElement, Root>();
+/** Attribute values that turn Sentry reporting off for a host element. */
+const SENTRY_OFF_VALUES = ['off', 'none'];
+
+/**
+ * Cache of already-created React roots, keyed by host element.
+ *
+ * The cache is kept on `globalThis` rather than in module scope so that a page
+ * which loads the bundle more than once (a cached inline copy alongside the CDN
+ * copy, say) re-renders into the existing root instead of calling `createRoot`
+ * twice on the same element.
+ */
+const globalScope = globalThis as typeof globalThis & {
+  __bukazuPortalRoots__?: WeakMap<HTMLElement, Root>;
+};
+const roots = (globalScope.__bukazuPortalRoots__ ??= new WeakMap<
+  HTMLElement,
+  Root
+>());
 
 /**
  * Parse the `filters` HTML attribute.
@@ -66,21 +91,38 @@ function parseFilters(raw: string | null): FiltersType {
 }
 
 /**
+ * Resolves the Sentry DSN for a host element.
+ *
+ * The `sentry-dsn` attribute wins when set to a non-empty value other than the
+ * opt-out keywords; otherwise the DSN baked into the bundle at build time is
+ * used. `undefined` leaves Sentry uninitialised, which the Portal component
+ * treats as "report nothing".
+ */
+function resolveSentryDsn(element: HTMLElement): string | undefined {
+  const raw = element.getAttribute('sentry-dsn');
+  if (raw !== null && SENTRY_OFF_VALUES.includes(raw)) {
+    return undefined;
+  }
+  return raw || __SENTRY_DSN__ || undefined;
+}
+
+/**
  * Mount a Portal onto a single host element.
  *
  * - `portal-code`: passed through as-is; when absent, the Portal component
  *   itself renders an error message.
- * - `language`: falls back to `'en'` when absent or unrecognised.
+ * - `language`: passed through as-is; the Portal component normalises BCP-47
+ *   tags and falls back to `'en'` for anything unsupported.
  * - `filters`:  falls back to `{}` when absent or invalid JSON.
+ * - `sentry-dsn`: see `resolveSentryDsn`.
  */
 function mountPortal(element: HTMLElement): void {
   const portalCode = element.getAttribute('portal-code') ?? '';
   const objectCode = element.getAttribute('object-code') ?? '';
   const pageType = element.getAttribute('page') ?? undefined;
-  const rawLocale = element.getAttribute('language');
-  const locale: LocaleType =
-    rawLocale && isLocaleType(rawLocale) ? rawLocale : 'en';
+  const locale = element.getAttribute('language') ?? undefined;
   const filters = parseFilters(element.getAttribute('filters'));
+  const sentryDsn = resolveSentryDsn(element);
 
   let root = roots.get(element);
   if (!root) {
@@ -94,20 +136,33 @@ function mountPortal(element: HTMLElement): void {
       pageType={pageType}
       locale={locale}
       filters={filters}
+      sentryDsn={sentryDsn}
     />
   );
 }
 
-/** Mount Portals on all `.bukazu-app` elements present in the document. */
+/**
+ * Mount Portals on every `.bukazu-app` element present in the document.
+ *
+ * When the page carries no such element, `#bukazu-app` is used instead: older
+ * embed snippets identify their host by id only. The fallback deliberately does
+ * not run when class-based hosts exist, so a page cannot gain an extra mount.
+ */
 function init(): void {
-  const elements = document.getElementsByClassName(CLASS_NAME);
-  for (const element of Array.from(elements)) {
-    mountPortal(element as HTMLElement);
-  }
-}
+  const elements = Array.from(
+    document.getElementsByClassName(CLASS_NAME)
+  ) as HTMLElement[];
 
-function isLocaleType(value: string): value is LocaleType {
-  return ['nl', 'en', 'de', 'es', 'fr', 'it'].includes(value);
+  if (elements.length === 0) {
+    const byId = document.getElementById(ELEMENT_ID);
+    if (byId) {
+      elements.push(byId);
+    }
+  }
+
+  for (const element of elements) {
+    mountPortal(element);
+  }
 }
 
 if (typeof document !== 'undefined') {
@@ -118,4 +173,7 @@ if (typeof document !== 'undefined') {
   }
 }
 
-export { init, mountPortal };
+/** Version of the package this bundle was built from. */
+const version = __PORTAL_VERSION__;
+
+export { init, mountPortal, version };

--- a/vite.website.config.ts
+++ b/vite.website.config.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
 /**
@@ -7,13 +8,112 @@ import react from '@vitejs/plugin-react';
  *
  * Unlike the library build (vite.config.ts), React and all other dependencies
  * are bundled into the output so that the resulting file can be dropped into
- * any HTML page without any additional tooling or package manager.
+ * any HTML page without any additional tooling or package manager. The
+ * stylesheet is injected by the bundle itself, so a single `<script>` tag is
+ * all an embedder needs.
  *
- * Output: build/portal.website.js  (IIFE, all dependencies inlined)
- *         build/portal.website.css (extracted styles)
+ * Output: build/portal.website.js  (IIFE, all dependencies and styles inlined)
+ *         build/portal.website.css (the same styles as a separate file, for
+ *                                   embedders whose CSP forbids inline styles)
  */
+
+const CSS_FILE_NAME = 'portal.website.css';
+const STYLE_ELEMENT_ID = 'bukazu-portal-styles';
+
+const { version } = JSON.parse(
+  readFileSync(resolve(__dirname, 'package.json'), 'utf8')
+) as { version: string };
+
+/**
+ * Renders a string as a JavaScript literal that is safe to embed in a
+ * `<script>` block. `JSON.stringify` handles quotes, backslashes, newlines and
+ * control characters; escaping `<` additionally neutralises `</script` and
+ * `<!--` sequences, both of which are legal inside CSS `content` values.
+ */
+function toJsLiteral(value: string): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
+ * The stylesheet injector that gets prepended to the bundle.
+ *
+ * It runs before the portal mounts, so styles are in place ahead of the first
+ * paint. The element id makes the injection idempotent: a page that loads the
+ * bundle twice still ends up with exactly one `<style>` element.
+ */
+function styleInjector(css: string): string {
+  return `(function(){try{
+if(typeof document==="undefined")return;
+if(document.getElementById(${toJsLiteral(STYLE_ELEMENT_ID)}))return;
+var s=document.createElement("style");
+s.id=${toJsLiteral(STYLE_ELEMENT_ID)};
+s.setAttribute("data-bukazu-version",${toJsLiteral(version)});
+var c=document.currentScript;if(c&&c.nonce)s.nonce=c.nonce;
+s.textContent=${toJsLiteral(css)};
+(document.head||document.documentElement).appendChild(s);
+}catch(e){}})();
+`;
+}
+
+/**
+ * Prepends the extracted stylesheet to the bundle as a self-injecting
+ * `<style>` element, so `portal.website.js` needs no companion `<link>`.
+ *
+ * Vite emits the library stylesheet from `vite:css-post`'s own `generateBundle`
+ * hook, and `cssPostPlugin` is ordered ahead of the post plugins, so an
+ * `enforce: 'post'` plugin with a `post`-ordered hook sees the finished CSS
+ * asset. The asset is deliberately left in the bundle: it is still published
+ * for embedders who load styles through a `<link>` tag.
+ */
+function inlineCss(): Plugin {
+  return {
+    name: 'bukazu:inline-css',
+    enforce: 'post',
+    generateBundle: {
+      order: 'post',
+      handler(_options, bundle) {
+        const asset = bundle[CSS_FILE_NAME];
+        if (!asset || asset.type !== 'asset') {
+          this.error(
+            `[bukazu:inline-css] ${CSS_FILE_NAME} is not in the bundle. ` +
+              `Present: ${Object.keys(bundle).join(', ')}`
+          );
+          return;
+        }
+
+        const css =
+          typeof asset.source === 'string'
+            ? asset.source
+            : Buffer.from(asset.source).toString('utf8');
+
+        const entry = Object.values(bundle).find(
+          (output) => output.type === 'chunk' && output.isEntry
+        );
+        if (!entry || entry.type !== 'chunk') {
+          this.error('[bukazu:inline-css] no entry chunk found');
+          return;
+        }
+
+        entry.code = styleInjector(css) + entry.code;
+      }
+    }
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), inlineCss()],
+  define: {
+    // Vite does not substitute `process.env.NODE_ENV` in library mode, and this
+    // bundle is loaded straight from a `<script>` tag with no bundler behind it
+    // to do the substitution. Without this, React's own `process.env.NODE_ENV`
+    // reads throw "process is not defined" and nothing renders.
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    __SENTRY_DSN__: JSON.stringify(process.env.BUKAZU_SENTRY_DSN ?? ''),
+    __PORTAL_VERSION__: JSON.stringify(version)
+  },
   build: {
     outDir: 'build',
     emptyOutDir: false,
@@ -35,11 +135,9 @@ export default defineConfig({
       formats: ['iife'],
       fileName: () => 'portal.website.js',
       cssFileName: 'portal.website'
-    },
-    rollupOptions: {
-      output: {
-        inlineDynamicImports: true
-      }
     }
+    // No `inlineDynamicImports`: the IIFE library format already disables code
+    // splitting, so rolldown ignores the option and warns about it. The locale
+    // and country payloads end up inlined either way.
   }
 });


### PR DESCRIPTION
## The headline

`build/portal.website.js` as published in `4.0.0-beta.3` **does not run**. It contains ten unsubstituted `process.env.NODE_ENV` references, so loading it through a `<script>` tag throws immediately:

```
PAGEERROR: process is not defined
BukazuPortal typeof: undefined
host innerHTML length: 0
```

Vite does not substitute `process.env.NODE_ENV` in library mode, and this bundle by design has no bundler behind it to do the substitution. The failure is invisible in unit tests (which mock React and the stylesheet) and there was no e2e coverage of the built file, so #324 shipped unverified. Defining it fixes the crash and drops the bundle **799 KB → 493 KB** (249 KB → 155 KB gzip), because React's development branches were being retained.

`portal.es.js` is unaffected — consumers' bundlers substitute it there.

## Why the rest of this PR

The goal is for `portaldeploy` to stop rebuilding this bundle by hand and simply ship the published one. That needs the artifact to be a drop-in replacement for what `portaldeploy` produces today, which means closing four gaps:

| Change | Reason |
|---|---|
| Stylesheet inlined into the bundle | Today's deployed `main.js` injects its own `<style>`; requiring a `<link>` would silently unstyle every hand-rolled embed. `portal.website.css` is still emitted for CSP-strict pages |
| `sentry-dsn` attribute + DSN baked in at build time (`BUKAZU_SENTRY_DSN` repo variable) | `portaldeploy` hardcodes the DSN today; without this, embeds lose error reporting. `sentry-dsn="off"` opts out |
| `#bukazu-app` fallback when nothing carries the class | The bundle in production supports id-only hosts; dropping that would blank those pages |
| `language` passed through to Portal | `isLocaleType` rejected BCP-47, so `language="nl-NL"` silently became English even though `normalizeLocale` handles it |

Plus: the root registry now lives on `globalThis`, so a page that ends up loading the bundle twice re-renders rather than calling `createRoot` twice on the same element.

## Verification this repo did not have

- `e2e/website-bundle.spec.ts` — loads the **real built file** from `scripts/serve-static.mjs` (a second `webServer` entry; the Vite dev server would transform it) and asserts: one injected `<style>`, no `<link>` needed, the rules actually apply, `BukazuPortal.{init,mountPortal,version}` exist, the portal mounts (proving React is inside), an id-only host mounts, a double load stays idempotent, and a Sentry envelope is sent.
- `scripts/verify-website-bundle.mjs` — gates the build on the injected stylesheet, the **absence of `process.env`**, the version stamp, and the DSN when `BUKAZU_SENTRY_DSN` is set. Wired into the `build` and `e2e` jobs and, critically, into the publish workflow.
- `bundle-size` pattern corrected to `./build/portal.{es,website}.js`. It was tracking a UMD build that has never existed while ignoring the largest bundle in the repo — that hunk was lost in #324's squash.

Ran locally on node 22: 729 unit tests pass, `src/website.tsx` at 100 % coverage (as AGENTS.md requires), overall coverage 91.13 % lines (master: 91.05), and all 8 e2e tests green against the built bundle.

## Note for the reviewer

`BUKAZU_SENTRY_DSN` must be set as an Actions **variable** (not a secret — a DSN is public by design, and masking only makes logs confusing) before the next release, or the published bundle ships with reporting disabled. The `verify:website` step in the publish job will not fail on an unset DSN, only on a DSN that was set but did not make it into the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)